### PR TITLE
Remove stream from docs platform taxonomy seed

### DIFF
--- a/inc/core/taxonomy-seed.php
+++ b/inc/core/taxonomy-seed.php
@@ -14,7 +14,6 @@
  * | artist-platform | artist-platform/  | artist.extrachill.com     |
  * | community       | community/        | community.extrachill.com  |
  * | events-calendar | events-calendar/  | events.extrachill.com     |
- * | stream          | stream/           | stream.extrachill.com     |
  * | newsletter      | newsletter/       | newsletter.extrachill.com |
  * | shop            | shop/             | shop.extrachill.com       |
  * | blog            | blog/             | extrachill.com            |
@@ -42,7 +41,6 @@ function extrachill_docs_seed_platforms() {
 		'artist-platform' => 'Artist Platform',
 		'community'       => 'Community',
 		'events-calendar' => 'Events',
-		'stream'          => 'Stream',
 		'newsletter'      => 'Newsletter',
 		'shop'            => 'Shop',
 		'blog'            => 'Blog',


### PR DESCRIPTION
## Summary

- Remove `'stream' => 'Stream'` from the `extrachill_docs_seed_platforms()` array
- Remove stream row from the platform mapping table in the file header comment

## Context

stream.extrachill.com has been decommissioned. The existing "Stream" taxonomy term in the database is harmless (it just won't show on the docs homepage since there are no published posts under it).