### PR TITLE
feat(reviews): add last-reviewed date to ec_doc (closes #10)

### DIFF
--- a/assets/js/last-reviewed-sidebar.js
+++ b/assets/js/last-reviewed-sidebar.js
@@ -1,0 +1,125 @@
+/**
+ * Last Reviewed sidebar panel for ec_doc.
+ *
+ * Adds a PluginDocumentSettingPanel with a date input and a
+ * "Mark reviewed today" button. Reads/writes the
+ * `_ec_doc_last_reviewed` post meta (Y-m-d string) via the core
+ * editor entity store. No build step — uses wp.element.createElement.
+ *
+ * @package ExtraChillDocs
+ * @since 0.5.0
+ */
+( function ( wp ) {
+	'use strict';
+
+	if ( ! wp || ! wp.plugins || ! wp.editPost || ! wp.element || ! wp.components || ! wp.data || ! wp.i18n ) {
+		return;
+	}
+
+	var el = wp.element.createElement;
+	var Fragment = wp.element.Fragment;
+	var registerPlugin = wp.plugins.registerPlugin;
+	var PluginDocumentSettingPanel = wp.editPost.PluginDocumentSettingPanel;
+	var Button = wp.components.Button;
+	var BaseControl = wp.components.BaseControl;
+	var useSelect = wp.data.useSelect;
+	var useDispatch = wp.data.useDispatch;
+	var __ = wp.i18n.__;
+
+	var META_KEY = '_ec_doc_last_reviewed';
+	var POST_TYPE = 'ec_doc';
+
+	function todayYmd() {
+		var now = new Date();
+		var y = now.getFullYear();
+		var m = String( now.getMonth() + 1 ).padStart( 2, '0' );
+		var d = String( now.getDate() ).padStart( 2, '0' );
+		return y + '-' + m + '-' + d;
+	}
+
+	function LastReviewedPanel() {
+		var data = useSelect(
+			function ( select ) {
+				var editor = select( 'core/editor' );
+				return {
+					postType: editor.getCurrentPostType(),
+					value: ( editor.getEditedPostAttribute( 'meta' ) || {} )[ META_KEY ] || '',
+				};
+			},
+			[]
+		);
+
+		var editPost = useDispatch( 'core/editor' ).editPost;
+
+		// Only render on ec_doc.
+		if ( data.postType !== POST_TYPE ) {
+			return null;
+		}
+
+		var setValue = function ( next ) {
+			var meta = {};
+			meta[ META_KEY ] = next;
+			editPost( { meta: meta } );
+		};
+
+		var inputId = 'ec-doc-last-reviewed-date';
+
+		return el(
+			PluginDocumentSettingPanel,
+			{
+				name: 'ec-doc-last-reviewed',
+				title: __( 'Last reviewed', 'extrachill-docs' ),
+				className: 'ec-doc-last-reviewed-panel',
+			},
+			el(
+				BaseControl,
+				{
+					id: inputId,
+					label: __( 'Review date', 'extrachill-docs' ),
+					help: __( 'When this doc was last verified for accuracy. Leave empty if never reviewed.', 'extrachill-docs' ),
+				},
+				el( 'input', {
+					id: inputId,
+					type: 'date',
+					className: 'components-text-control__input',
+					value: data.value || '',
+					onChange: function ( event ) {
+						setValue( event.target.value || '' );
+					},
+				} )
+			),
+			el(
+				'div',
+				{ style: { display: 'flex', gap: '8px', marginTop: '8px' } },
+				el(
+					Button,
+					{
+						variant: 'secondary',
+						onClick: function () {
+							setValue( todayYmd() );
+						},
+					},
+					__( 'Mark reviewed today', 'extrachill-docs' )
+				),
+				data.value
+					? el(
+							Button,
+							{
+								variant: 'tertiary',
+								isDestructive: true,
+								onClick: function () {
+									setValue( '' );
+								},
+							},
+							__( 'Clear', 'extrachill-docs' )
+					  )
+					: null
+			)
+		);
+	}
+
+	registerPlugin( 'extrachill-docs-last-reviewed', {
+		render: LastReviewedPanel,
+		icon: 'calendar-alt',
+	} );
+} )( window.wp );

--- a/extrachill-docs.php
+++ b/extrachill-docs.php
@@ -45,6 +45,9 @@ require_once EXTRACHILL_DOCS_PLUGIN_DIR . 'inc/core/filters.php';
 // Sidebar integration.
 require_once EXTRACHILL_DOCS_PLUGIN_DIR . 'inc/core/sidebar.php';
 
+// Last reviewed date (post meta + editor sidebar + admin column).
+require_once EXTRACHILL_DOCS_PLUGIN_DIR . 'inc/core/last-reviewed.php';
+
 // Custom rewrite rules for /{platform}/{doc}/ URL structure.
 require_once EXTRACHILL_DOCS_PLUGIN_DIR . 'inc/core/rewrite-rules.php';
 

--- a/inc/core/last-reviewed.php
+++ b/inc/core/last-reviewed.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Last Reviewed Date for ec_doc
+ *
+ * Tracks when each documentation article was last reviewed for accuracy.
+ * Editors set the date manually; nothing is auto-backfilled.
+ *
+ * This module currently registers the `_ec_doc_last_reviewed` post meta
+ * (string, Y-m-d) and exposes it to the REST API so the editor sidebar
+ * and admin tooling can read/write it. The editor UI and admin list
+ * column are layered on top in subsequent changes.
+ *
+ * @package ExtraChillDocs
+ * @since 0.5.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Meta key for the last-reviewed date (string, Y-m-d).
+ *
+ * @since 0.5.0
+ */
+const EXTRACHILL_DOCS_LAST_REVIEWED_META_KEY = '_ec_doc_last_reviewed';
+
+add_action( 'init', 'extrachill_docs_register_last_reviewed_meta' );
+
+/**
+ * Registers `_ec_doc_last_reviewed` post meta on the ec_doc post type.
+ *
+ * REST-exposed so the editor sidebar can read/write it via the core
+ * entity store. Stored as `string` in `Y-m-d` format. Empty string means
+ * "never reviewed" (the default for existing docs — no auto-backfill).
+ *
+ * @since 0.5.0
+ * @return void
+ */
+function extrachill_docs_register_last_reviewed_meta() {
+	register_post_meta(
+		'ec_doc',
+		EXTRACHILL_DOCS_LAST_REVIEWED_META_KEY,
+		array(
+			'type'              => 'string',
+			'description'       => __( 'Date the doc was last reviewed for accuracy (Y-m-d).', 'extrachill-docs' ),
+			'single'            => true,
+			'default'           => '',
+			'show_in_rest'      => true,
+			'sanitize_callback' => 'extrachill_docs_sanitize_last_reviewed_date',
+			'auth_callback'     => function () {
+				return current_user_can( 'edit_posts' );
+			},
+		)
+	);
+}
+
+/**
+ * Sanitizes a Y-m-d date string. Returns '' for invalid input.
+ *
+ * @since 0.5.0
+ * @param mixed $value Raw meta value.
+ * @return string Sanitized Y-m-d date or empty string.
+ */
+function extrachill_docs_sanitize_last_reviewed_date( $value ) {
+	if ( ! is_string( $value ) || '' === $value ) {
+		return '';
+	}
+
+	$value = trim( $value );
+	$date  = DateTime::createFromFormat( 'Y-m-d', $value );
+
+	if ( ! $date || $date->format( 'Y-m-d' ) !== $value ) {
+		return '';
+	}
+
+	return $value;
+}

--- a/inc/core/last-reviewed.php
+++ b/inc/core/last-reviewed.php
@@ -25,8 +25,21 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 const EXTRACHILL_DOCS_LAST_REVIEWED_META_KEY = '_ec_doc_last_reviewed';
 
+/**
+ * Stale thresholds in days.
+ *
+ * @since 0.5.0
+ */
+const EXTRACHILL_DOCS_STALE_AMBER_DAYS = 90;
+const EXTRACHILL_DOCS_STALE_RED_DAYS   = 180;
+
 add_action( 'init', 'extrachill_docs_register_last_reviewed_meta' );
 add_action( 'enqueue_block_editor_assets', 'extrachill_docs_enqueue_last_reviewed_sidebar' );
+add_filter( 'manage_ec_doc_posts_columns', 'extrachill_docs_register_last_reviewed_column' );
+add_action( 'manage_ec_doc_posts_custom_column', 'extrachill_docs_render_last_reviewed_column', 10, 2 );
+add_filter( 'manage_edit-ec_doc_sortable_columns', 'extrachill_docs_register_last_reviewed_sortable' );
+add_action( 'pre_get_posts', 'extrachill_docs_apply_last_reviewed_sort' );
+add_action( 'admin_print_styles-edit.php', 'extrachill_docs_print_last_reviewed_admin_styles' );
 
 /**
  * Registers `_ec_doc_last_reviewed` post meta on the ec_doc post type.
@@ -114,4 +127,149 @@ function extrachill_docs_enqueue_last_reviewed_sidebar() {
 	);
 
 	wp_set_script_translations( 'extrachill-docs-last-reviewed-sidebar', 'extrachill-docs' );
+}
+
+/**
+ * Adds the "Last reviewed" column to the ec_doc list table.
+ *
+ * Inserted before the Date column for visual proximity to other dates.
+ *
+ * @since 0.5.0
+ * @param array $columns Existing columns.
+ * @return array Modified columns.
+ */
+function extrachill_docs_register_last_reviewed_column( $columns ) {
+	$new = array();
+	foreach ( $columns as $key => $label ) {
+		if ( 'date' === $key ) {
+			$new['ec_doc_last_reviewed'] = __( 'Last reviewed', 'extrachill-docs' );
+		}
+		$new[ $key ] = $label;
+	}
+
+	// Fallback: append if Date column was absent.
+	if ( ! isset( $new['ec_doc_last_reviewed'] ) ) {
+		$new['ec_doc_last_reviewed'] = __( 'Last reviewed', 'extrachill-docs' );
+	}
+
+	return $new;
+}
+
+/**
+ * Renders the Last reviewed column cell.
+ *
+ * Color hints:
+ *  - never reviewed → muted "Never"
+ *  - >180 days      → red
+ *  - >90 days       → amber
+ *  - otherwise      → plain
+ *
+ * @since 0.5.0
+ * @param string $column  Column slug.
+ * @param int    $post_id Post ID.
+ * @return void
+ */
+function extrachill_docs_render_last_reviewed_column( $column, $post_id ) {
+	if ( 'ec_doc_last_reviewed' !== $column ) {
+		return;
+	}
+
+	$value = get_post_meta( $post_id, EXTRACHILL_DOCS_LAST_REVIEWED_META_KEY, true );
+
+	if ( '' === $value ) {
+		echo '<span class="ec-doc-reviewed ec-doc-reviewed--never">' . esc_html__( 'Never', 'extrachill-docs' ) . '</span>';
+		return;
+	}
+
+	$reviewed = DateTime::createFromFormat( 'Y-m-d', $value );
+	if ( ! $reviewed ) {
+		echo '<span class="ec-doc-reviewed ec-doc-reviewed--never">' . esc_html__( 'Never', 'extrachill-docs' ) . '</span>';
+		return;
+	}
+
+	$now      = new DateTime( 'now', $reviewed->getTimezone() );
+	$age_days = (int) $now->diff( $reviewed )->days;
+
+	$class = 'ec-doc-reviewed';
+	if ( $age_days > EXTRACHILL_DOCS_STALE_RED_DAYS ) {
+		$class .= ' ec-doc-reviewed--red';
+	} elseif ( $age_days > EXTRACHILL_DOCS_STALE_AMBER_DAYS ) {
+		$class .= ' ec-doc-reviewed--amber';
+	}
+
+	$display = mysql2date( get_option( 'date_format' ), $value . ' 00:00:00' );
+
+	printf(
+		'<span class="%1$s" title="%2$s">%3$s</span>',
+		esc_attr( $class ),
+		esc_attr(
+			sprintf(
+				/* translators: %d: age in days */
+				_n( '%d day ago', '%d days ago', $age_days, 'extrachill-docs' ),
+				$age_days
+			)
+		),
+		esc_html( $display )
+	);
+}
+
+/**
+ * Marks the Last reviewed column as sortable.
+ *
+ * @since 0.5.0
+ * @param array $columns Sortable columns.
+ * @return array
+ */
+function extrachill_docs_register_last_reviewed_sortable( $columns ) {
+	$columns['ec_doc_last_reviewed'] = 'ec_doc_last_reviewed';
+	return $columns;
+}
+
+/**
+ * Applies a meta-based sort when the user clicks the column header.
+ *
+ * Uses meta_value (string compare) since dates are zero-padded Y-m-d
+ * which sorts lexicographically the same as chronologically. Posts
+ * without the meta sort to the bottom on ASC and top on DESC, which
+ * matches WordPress's default LEFT JOIN behavior.
+ *
+ * @since 0.5.0
+ * @param WP_Query $query Current query.
+ * @return void
+ */
+function extrachill_docs_apply_last_reviewed_sort( $query ) {
+	if ( ! is_admin() || ! $query->is_main_query() ) {
+		return;
+	}
+
+	if ( 'ec_doc_last_reviewed' !== $query->get( 'orderby' ) ) {
+		return;
+	}
+
+	$query->set( 'meta_key', EXTRACHILL_DOCS_LAST_REVIEWED_META_KEY );
+	$query->set( 'orderby', 'meta_value' );
+}
+
+/**
+ * Prints minimal admin CSS for the Last reviewed column.
+ *
+ * Inlined so we don't add a new stylesheet for a few selectors.
+ *
+ * @since 0.5.0
+ * @return void
+ */
+function extrachill_docs_print_last_reviewed_admin_styles() {
+	$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+	if ( ! $screen || 'edit-ec_doc' !== $screen->id ) {
+		return;
+	}
+
+	?>
+	<style>
+		.column-ec_doc_last_reviewed { width: 12em; }
+		.ec-doc-reviewed--never { color: #757575; font-style: italic; }
+		.ec-doc-reviewed--amber { color: #b26200; font-weight: 600; }
+		.ec-doc-reviewed--red { color: #b32d2e; font-weight: 600; }
+	</style>
+	<?php
 }

--- a/inc/core/last-reviewed.php
+++ b/inc/core/last-reviewed.php
@@ -26,6 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 const EXTRACHILL_DOCS_LAST_REVIEWED_META_KEY = '_ec_doc_last_reviewed';
 
 add_action( 'init', 'extrachill_docs_register_last_reviewed_meta' );
+add_action( 'enqueue_block_editor_assets', 'extrachill_docs_enqueue_last_reviewed_sidebar' );
 
 /**
  * Registers `_ec_doc_last_reviewed` post meta on the ec_doc post type.
@@ -75,4 +76,42 @@ function extrachill_docs_sanitize_last_reviewed_date( $value ) {
 	}
 
 	return $value;
+}
+
+/**
+ * Enqueues the Gutenberg sidebar panel script on ec_doc edit screens.
+ *
+ * No build step: hand-written ES module that consumes WP globals.
+ *
+ * @since 0.5.0
+ * @return void
+ */
+function extrachill_docs_enqueue_last_reviewed_sidebar() {
+	$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+	if ( ! $screen || 'ec_doc' !== $screen->post_type ) {
+		return;
+	}
+
+	$script_path = EXTRACHILL_DOCS_PLUGIN_DIR . 'assets/js/last-reviewed-sidebar.js';
+	if ( ! file_exists( $script_path ) ) {
+		return;
+	}
+
+	wp_enqueue_script(
+		'extrachill-docs-last-reviewed-sidebar',
+		EXTRACHILL_DOCS_PLUGIN_URL . 'assets/js/last-reviewed-sidebar.js',
+		array(
+			'wp-element',
+			'wp-plugins',
+			'wp-edit-post',
+			'wp-components',
+			'wp-data',
+			'wp-i18n',
+			'wp-compose',
+		),
+		filemtime( $script_path ),
+		true
+	);
+
+	wp_set_script_translations( 'extrachill-docs-last-reviewed-sidebar', 'extrachill-docs' );
 }


### PR DESCRIPTION
## Summary

Adds a `_ec_doc_last_reviewed` date field to the `ec_doc` post type so editors can mark when a doc was last verified for accuracy. Stale docs get color-coded in the admin list.

Closes #10.

## What's in the PR

1. **Post meta** (`b514296`) — registers `_ec_doc_last_reviewed` (string, `Y-m-d`) on `ec_doc` via `register_post_meta` with `show_in_rest: true`. Sanitizer rejects anything that isn't a well-formed date (round-trips through `DateTime::createFromFormat('Y-m-d', ...)`).
2. **Editor sidebar** (`0bd0695`) — `PluginDocumentSettingPanel` with a native `<input type=\"date\">`, *Mark reviewed today* button, and a *Clear* button when a value is set. Hand-written ES module (`assets/js/last-reviewed-sidebar.js`) — **no build pipeline added**. Reads/writes via `core/editor` entity store so it saves alongside the post.
3. **Admin column** (`bc2d365`) — sortable *Last reviewed* column on the `ec_doc` list table:
   - never reviewed → italic, muted *Never*
   - >90 days → amber
   - >180 days → red
   - hover title shows age in days
   - sort uses `meta_value` (zero-padded Y-m-d sorts correctly as a string)

## Backfill policy

The 16 existing docs are **not auto-backfilled** — they show as *Never* until an editor opens each one and sets a date. This is intentional: the whole point of \"last reviewed\" is that a human eyeballed the content recently. A scripted backfill would be lying.

## File layout

```
inc/core/last-reviewed.php           (meta + enqueue + admin column, all hooks)
assets/js/last-reviewed-sidebar.js   (no-build sidebar panel)
extrachill-docs.php                  (require_once for the new module)
```

## Verification

- [x] PHP lint clean on all touched files
- [x] Sanitizer correctness verified via `wp eval`:
  - `''`, `'2026-04-28'`, `'  2026-04-28  '` round-trip correctly
  - `'2026-13-01'`, `'2026-04-31'`, `'2026-4-1'`, `'not-a-date'` all sanitize to `''`
- [x] Stale bucketing verified (0d=OK, 30d=OK, 91d=AMBER, 181d=RED)
- [x] `git diff main --stat` is 3 files / +403 LOC

## Out of scope (follow-up)

- **`wp extrachill docs stale [--days=180]` CLI command** — belongs in `extrachill-cli` (which uses `inc/Commands/` PSR-4 autoloading), not in this plugin. Will open a separate PR there. The admin column already gives editors the same signal interactively.
- **Frontend display of the review date** — that's a theme concern. Not touched here.
- **Version bumps / changelog** — Homeboy owns those at release time per repo policy. No `homeboy.json` or `extrachill-docs.php` Version header changes in this PR.

@chubes