### PR TITLE
docs(drafts): newsletter help articles (refs #11)

### DIFF
--- a/drafts/newsletter/read-past-issues.md
+++ b/drafts/newsletter/read-past-issues.md
@@ -1,0 +1,34 @@
+# Read past issues
+
+Missed last Sunday's email? Want to see what we wrote about a band a few months back? You can read every Sunday email we've ever sent right on our website. No sign-up needed — it's all out in the open.
+
+## Where to find the archive
+
+Head to [newsletter.extrachill.com](https://newsletter.extrachill.com). You'll see a list of past emails, with the newest one at the top.
+
+![The list of past Sunday emails](screenshot-needed-1.png)
+
+Each one shows the title and the date we sent it.
+
+## How to read one
+
+Click any title and the full email opens up on the page — same words, same links, same songs as the version that landed in inboxes that Sunday. You can read it right in your browser.
+
+![A past email open on the website](screenshot-needed-2.png)
+
+## Looking for something specific?
+
+Two ways to find what you want:
+
+1. **Scroll the list** — newer emails are up top, older ones further down. You can flip through pages at the bottom of the list.
+2. **Use search** — click the search icon in the top corner of the page and type a band name, a song, or any word you remember.
+
+![The search box on the newsletter page](screenshot-needed-3.png)
+
+## Want the next one in your inbox?
+
+Reading old emails is great, but the new ones land Sunday morning. If you want to catch them as they go out, see [Sign up for the Sunday newsletter](sign-up-for-the-sunday-newsletter.md).
+
+## Need help?
+
+If you have questions, [contact us](https://extrachill.com/contact/) or visit our [community forum](https://community.extrachill.com).

--- a/drafts/newsletter/sign-up-for-the-sunday-newsletter.md
+++ b/drafts/newsletter/sign-up-for-the-sunday-newsletter.md
@@ -1,0 +1,36 @@
+# Sign up for the Sunday newsletter
+
+Want a hand-picked dose of independent music in your inbox every Sunday? Our weekly email is the easiest way to keep up with what we're listening to, the bands we're covering, and the shows worth knowing about. It only takes a few seconds to sign up.
+
+## Where to find the signup form
+
+You'll see a **Subscribe** button on most pages of Extra Chill. The quickest spot is the bottom of any article, but you can also find it on the [newsletter page](https://newsletter.extrachill.com).
+
+![Subscribe button at the bottom of an article](screenshot-needed-1.png)
+
+Click **Subscribe** and a small form will pop open.
+
+## What to enter
+
+The form asks for two things:
+
+1. Your **first name** — so we can say hi
+2. Your **email address** — where you want the email to land
+
+![The signup form with name and email fields](screenshot-needed-2.png)
+
+Hit **Subscribe** and you're done. No password, no extra steps.
+
+## What happens next
+
+Right after you sign up, we'll send a quick welcome email so you know it worked. Look for it in your inbox in the next minute or two. If you don't see it, check your spam or promotions folder and drag it over to your main inbox so future emails land in the right place.
+
+After that, the next Sunday email goes out at the end of the week. You'll start getting it every Sunday morning from then on.
+
+## Changed your mind?
+
+No worries. Every email we send has an unsubscribe link at the bottom. One click and you're out — no questions asked. See [Stop getting our emails](stop-getting-our-emails.md) if you need a hand.
+
+## Need help?
+
+If you have questions, [contact us](https://extrachill.com/contact/) or visit our [community forum](https://community.extrachill.com).

--- a/drafts/newsletter/stop-getting-our-emails.md
+++ b/drafts/newsletter/stop-getting-our-emails.md
@@ -1,0 +1,35 @@
+# Stop getting our emails
+
+Not feeling the Sunday email anymore? That's okay. You can stop getting our emails any time, and it only takes one click. We'd rather you stick around because you want to than feel stuck with a full inbox.
+
+## How to unsubscribe
+
+Open any email you've gotten from us and scroll all the way to the bottom. You'll see a small **Unsubscribe** link.
+
+![The unsubscribe link at the bottom of an email](screenshot-needed-1.png)
+
+Click it. That's it — you're off the list. You won't get the Sunday email anymore.
+
+## How long does it take?
+
+The change happens right away. If a Sunday email was already on its way when you clicked unsubscribe, you might still get that one. After that, no more.
+
+## What if you change your mind?
+
+We get it — sometimes you miss a thing once it's gone. If you want back in, just sign up again on the [newsletter page](https://newsletter.extrachill.com) or hit **Subscribe** at the bottom of any article. You'll be back on the list right away.
+
+See [Sign up for the Sunday newsletter](sign-up-for-the-sunday-newsletter.md) for the steps.
+
+## Can't find the unsubscribe link?
+
+Some email apps hide tiny text. Try these tricks:
+
+- Scroll all the way past the very last word of the email
+- Open the email in a web browser instead of your phone app
+- Search the email for the word **unsubscribe**
+
+If you still can't find it, [contact us](https://extrachill.com/contact/) and we'll take you off the list ourselves.
+
+## Need help?
+
+If you have questions, [contact us](https://extrachill.com/contact/) or visit our [community forum](https://community.extrachill.com).

--- a/drafts/newsletter/whats-in-the-sunday-email.md
+++ b/drafts/newsletter/whats-in-the-sunday-email.md
@@ -1,0 +1,40 @@
+# What's in the Sunday email
+
+Every Sunday, we send out a fresh email full of music we think you'll love. It's short enough to read with your morning coffee and packed with stuff you won't find by scrolling your usual feeds. Here's what to expect.
+
+## When it lands
+
+Sunday morning, every week. Most folks see it in their inbox before noon.
+
+![The Sunday email in an inbox](screenshot-needed-1.png)
+
+## What's inside
+
+Each email is a little different, but you can usually count on:
+
+- **A note from us** — a short intro about the week, what we've been into, or what's coming up
+- **New music** — songs and albums from independent artists that caught our ear
+- **Stories worth reading** — interviews, live show reviews, and music news from our writers
+- **Shows on the calendar** — gigs and festivals we're excited about
+
+![Sample sections inside a Sunday email](screenshot-needed-2.png)
+
+## Who picks the music
+
+Real people. The Extra Chill team has been writing about independent music since 2011, and the songs and bands you'll see in the email are picks from us — not a robot, not a chart, not whoever paid the most. If a song is in the email, somebody on our team thought you should hear it.
+
+## How long is it?
+
+Short. We try to keep each email to a few minutes of reading. If something needs a deeper dive, we link out so you can read the full thing on the website when you have time.
+
+## Can I read old ones?
+
+Yes. Every Sunday email goes into our archive so you can catch up on what you missed. See [Read past issues](read-past-issues.md).
+
+## Want in?
+
+If you're not on the list yet, see [Sign up for the Sunday newsletter](sign-up-for-the-sunday-newsletter.md). It only takes a few seconds.
+
+## Need help?
+
+If you have questions, [contact us](https://extrachill.com/contact/) or visit our [community forum](https://community.extrachill.com).


### PR DESCRIPTION
## Summary

Drafts of 4 newsletter help articles for review, per #11.

Articles included:

- `drafts/newsletter/sign-up-for-the-sunday-newsletter.md` — where to find the form, what to enter, what happens after
- `drafts/newsletter/stop-getting-our-emails.md` — how to unsubscribe, what to do if the link is hidden, how to come back
- `drafts/newsletter/whats-in-the-sunday-email.md` — when it lands, what's inside, who picks the music
- `drafts/newsletter/read-past-issues.md` — where the archive lives, how to find a specific issue

## Skipped

**Send a newsletter to your fans** — skipped intentionally. Artists don't have a way to send their own newsletter through Extra Chill today, so there's nothing to document. @chubes flag if I missed a feature; otherwise leave this off the list until that capability ships.

## Writing rules check

Each article was scanned for banned terms (API, endpoint, service, platform-as-tech, subscriber, opt-in, vendor names, infrastructure language, "your subscription", etc.) — all clean. Word counts 254–317, well inside the 200–500 range. Sixth-grade reading level, "you" not "users", no acronyms.

## Screenshots

Each article references screenshots as `![alt text](screenshot-needed-N.png)` placeholders. They aren't created yet — flagged inline so whoever edits these can drop in real images:

- Subscribe button on an article
- Signup form (name + email fields)
- Unsubscribe link at the bottom of an email
- Sunday email in an inbox
- Sample sections inside a Sunday email
- The newsletter archive list
- A past email open on the website
- The search box on the newsletter page

## Notes

- Cross-links between articles use relative `.md` links that the docs site's link rewriter should handle when these get published.
- "Need help?" footer is identical across all four, linking contact + community forum.

cc @chubes