### PR TITLE
docs(drafts): shop help articles (refs #12)

### DIFF
--- a/drafts/shop/buying-merch-from-your-favorite-artists.md
+++ b/drafts/shop/buying-merch-from-your-favorite-artists.md
@@ -1,0 +1,52 @@
+# Buying Merch From Your Favorite Artists
+
+The Extra Chill Shop isn't just our merch — it's a marketplace where independent artists set up their own merch booths. When you buy a shirt or sticker from an artist on Extra Chill, the money goes to them, and your support goes straight to the people making the music.
+
+Here's how it works for you as a buyer.
+
+## How to Find Artist Merch
+
+There are two easy ways:
+
+- **Browse the shop and filter by artist.** On the main shop page, use the **All Artists** dropdown to pick an artist and see only their items.
+- **Visit the artist's link page.** Many artists link their merch from their Extra Chill link page so you can go straight from a song to a shirt.
+
+Each item shows the artist's name above the title, so it's clear who you're buying from.
+
+![Screenshot: artist filter dropdown on the shop home page]
+
+## What's the Same as Any Other Order
+
+For you, buying artist merch works the same as buying anything else in the shop:
+
+- You add items to one cart
+- You check out one time, even if your cart has merch from more than one artist
+- You pay through Extra Chill, not through a separate site
+- You get one confirmation email and one order number for the whole order
+
+For more on the basic flow, see [Find and Buy Something](find-and-buy-something.md) and [Paying](paying.md).
+
+## What's Different
+
+A few things to know about artist merch:
+
+- **The artist fulfills the order.** They're the ones printing the shirt or packing the package. Most items are made to order, so production can take **2 to 7 business days** before shipping. See [When Your Order Ships](when-your-order-ships.md).
+- **Shipping costs vary by artist.** Different artists ship from different places, so the cost depends on where the artist is and where you are.
+- **Returns go through Extra Chill.** Even though the artist fulfilled the order, you contact us first if there's a problem. See [Returns and Refunds](returns-and-refunds.md).
+
+## Why Buy Direct From Artists Here
+
+When you buy artist merch through the Extra Chill Shop:
+
+- The artist gets paid directly for what they sell
+- You're supporting independent music, not a middleman
+- Everything is in one place — your favorite blog, the community, and the merch
+
+Want to support an artist but they're not in the shop yet? Send them a link to [the Artist Platform](https://artist.extrachill.com) and tell them to set up shop.
+
+## Need Help?
+
+If something's wrong with an artist merch order:
+
+- [Contact us](https://extrachill.com/contact/) — we route the issue to the right person
+- Ask in the [Tech Support forum](https://community.extrachill.com/r/tech-support)

--- a/drafts/shop/find-and-buy-something.md
+++ b/drafts/shop/find-and-buy-something.md
@@ -1,0 +1,66 @@
+# Find and Buy Something
+
+The Extra Chill Shop is where you can pick up stickers, shirts, and other merch — both from Extra Chill and from artists in our community. Here's how to find what you want and buy it.
+
+## Browse the Shop
+
+Visit [shop.extrachill.com](https://shop.extrachill.com) to see what's available. The main page lists every item that's currently for sale. You can sort the list a few different ways:
+
+- **Recent** — newest items first
+- **Oldest** — original listings first
+- **Price: Low to High** or **High to Low**
+- **Popular** — what other people are buying
+
+You can also filter by artist. Use the **All Artists** dropdown at the top of the listing to narrow the page down to one artist's merch.
+
+![Screenshot: shop home page with the artist filter and sort dropdowns visible]
+
+## Open an Item
+
+Click any item to see its full page. There you'll find:
+
+- Bigger photos of the item
+- A full description
+- Size options, if the item comes in sizes
+- The price
+- Whether it's in stock
+
+If an item is out of stock, the page will say so. You won't be able to add it to your cart until it's back.
+
+## Add to Your Cart
+
+When you've found something you want, choose your size or other options if needed, then click **Add to cart**. The cart icon at the top of the page will update to show how many items you've added.
+
+You can keep shopping and add more items, or go straight to your cart to check out.
+
+![Screenshot: an item page with size selector and the Add to cart button]
+
+## Review Your Cart
+
+Click the cart icon to see everything you've added. From the cart you can:
+
+- Change how many of each item you want
+- Remove items you don't want anymore
+- See the total before shipping
+- Move on to checkout
+
+Shipping costs are figured out at checkout, once you've entered your address. They depend on where you live and how heavy the order is. Stickers ship for free.
+
+## Check Out
+
+Click **Checkout** when you're ready to buy. You'll enter:
+
+- Your shipping address
+- Your contact email
+- Your payment details
+
+Once you confirm the order, you'll see a confirmation page with your order number, and you'll get a confirmation email with the same info. Hold onto that — it's how you'll track the order later.
+
+For more on payment, see [Paying](paying.md). For what happens after you place an order, see [When Your Order Ships](when-your-order-ships.md).
+
+## Need Help?
+
+If something isn't working in the shop or you have a question about an item:
+
+- [Contact us](https://extrachill.com/contact/)
+- Ask in the [Tech Support forum](https://community.extrachill.com/r/tech-support)

--- a/drafts/shop/paying.md
+++ b/drafts/shop/paying.md
@@ -1,0 +1,60 @@
+# Paying
+
+Here's what to expect when it's time to pay for your order.
+
+## What You Can Pay With
+
+At checkout, you can pay with:
+
+- A credit card (Visa, Mastercard, American Express, Discover)
+- A debit card with a Visa or Mastercard logo
+- Apple Pay or Google Pay, if your device supports them
+
+You enter your card details on the checkout page. The order total — items plus shipping and any taxes — is shown clearly before you confirm.
+
+![Screenshot: checkout page with order total breakdown and payment field]
+
+## Is Checkout Secure?
+
+Yes. Your payment details are entered on a secure page and sent through an encrypted connection. We don't store your full card number on Extra Chill — only the receipt info we need to show you what you bought.
+
+If your browser shows a lock icon next to the address bar at checkout, you're on the secure page.
+
+## Do You Need an Account?
+
+You don't need an Extra Chill account to buy something. You can check out as a guest using just your email and shipping address.
+
+That said, having an account has a few perks:
+
+- You can see all your past orders in one place. See [See Your Past Orders](see-your-past-orders.md).
+- Your shipping address is saved, so checkout is faster next time.
+- You're already signed in across the rest of Extra Chill — community, link pages, the lot.
+
+You can [create an account](https://shop.extrachill.com/login/#tab-register) before you check out, or check out as a guest and register later.
+
+## When You're Charged
+
+Your card is charged when you confirm the order, not when the order ships. The charge will show up on your statement under an Extra Chill name.
+
+If the charge fails — for example, your card is expired or your bank declines it — you'll see an error on the checkout page and the order won't go through. Try a different card, or check with your bank.
+
+## Sales Tax
+
+Sales tax is added at checkout based on where you live. The total you see before confirming is the total you pay — there are no surprise charges later.
+
+## What to Do if Something Goes Wrong
+
+If you were charged but didn't get a confirmation email, or the charge looks wrong:
+
+- Check your spam folder for the confirmation email
+- Look for the charge on your card statement to see the merchant name
+- [Contact us](https://extrachill.com/contact/) with the date and amount and we'll track it down
+
+For refunds after a return, see [Returns and Refunds](returns-and-refunds.md).
+
+## Need Help?
+
+Payment problems are usually fastest to resolve over email:
+
+- [Contact us](https://extrachill.com/contact/)
+- Ask in the [Tech Support forum](https://community.extrachill.com/r/tech-support)

--- a/drafts/shop/returns-and-refunds.md
+++ b/drafts/shop/returns-and-refunds.md
@@ -1,0 +1,57 @@
+# Returns and Refunds
+
+We want you to like what you ordered. Here's straight talk on what we can and can't take back, and how to start a return.
+
+## What You Can Return
+
+### Damaged or Defective Items
+
+If your item shows up damaged, or it's defective in some way, we'll make it right. Reach out within **30 days** of getting the package and include photos of the problem. If we confirm the issue, we'll send a free replacement.
+
+### Size Issues
+
+If a piece of clothing doesn't fit, we'll review size exchanges **case by case**. We can't promise an exchange every time, and you may have to pay the cost of shipping the new size.
+
+Before you order, take a minute to check the size chart on the item's page. Returning a size that turns out wrong is the most common reason a return falls through.
+
+## What You Can't Return
+
+Be honest with yourself before you buy:
+
+- **Change of mind returns are not accepted.** If you decide later you don't want it, we can't take it back.
+- **Wrong size you ordered yourself.** If the size chart was on the page and you picked the wrong size, that's not something we can refund.
+- **Made-to-order items** are produced just for you. Once production starts, the order can't be cancelled.
+
+## How Long You Have
+
+For damaged or defective items: **30 days** from when the package arrived.
+
+The clock starts on the delivery date shown by the carrier, not the order date.
+
+## How to Start a Return
+
+Don't ship anything back before you contact us. Returns sent without warning may not get processed.
+
+1. **[Contact us](https://extrachill.com/contact/)** with your order number and the reason for the return
+2. **Include photos** if the item is damaged or defective
+3. **Wait for return authorization** — we'll write back with what to do next
+4. **Follow the instructions** we send, including the return address and any forms
+
+![Screenshot: contact form with order number field highlighted]
+
+## When You'll Get Your Refund
+
+Once we receive the returned item and confirm it qualifies, the refund goes back to your original payment method. **It can take up to 10 business days** for the refund to show up in your account, depending on your bank or card.
+
+Replacements for damaged items go out as a fresh order, so they follow the same production and shipping timelines as a new order. See [When Your Order Ships](when-your-order-ships.md) for what to expect.
+
+## Lost Packages
+
+If a package was marked delivered by the carrier but never showed up, that's not the same as a return. See [When Your Order Ships](when-your-order-ships.md) for what to do.
+
+## Need Help?
+
+To start a return or ask whether something qualifies:
+
+- [Contact us](https://extrachill.com/contact/)
+- Ask in the [Tech Support forum](https://community.extrachill.com/r/tech-support)

--- a/drafts/shop/see-your-past-orders.md
+++ b/drafts/shop/see-your-past-orders.md
@@ -1,0 +1,60 @@
+# See Your Past Orders
+
+If you've bought something from the Extra Chill Shop before, you can look it up later — to track a package, find a receipt, or remember what size you ordered last time.
+
+## If You Have an Account
+
+The easiest way is to sign in.
+
+1. Go to [shop.extrachill.com](https://shop.extrachill.com) and click **Log In** in the top right
+2. Sign in with your Extra Chill account
+3. Open the account menu and choose **Orders**
+
+You'll see every order you've placed, with the most recent at the top. Each row shows:
+
+- The order number
+- The date you ordered
+- How much you paid
+- Whether it's still being made, has shipped, or was delivered
+
+Click an order to see the full details — the items, the shipping address, the tracking number if it's already on the way, and a printable receipt.
+
+![Screenshot: account orders page with a list of past orders and their status]
+
+## If You Checked Out as a Guest
+
+If you didn't have an account when you ordered, you can still find your order — you just need the confirmation email we sent you.
+
+That email has:
+
+- Your **order number** (you'll need this if you contact us)
+- Your **tracking number** once the order ships
+- A **receipt** with what you paid
+
+If you can't find the email:
+
+- Search your inbox for "Extra Chill" or your order date
+- Check your spam or promotions folder
+- [Contact us](https://extrachill.com/contact/) with the email address and approximate date you used to order, and we'll look it up
+
+## Get Your Past Orders Into an Account
+
+If you ordered as a guest and now want all your orders in one place, [create an account](https://shop.extrachill.com/login/#tab-register) using the same email you ordered with. Past guest orders made with that email will show up in your account.
+
+## What an Order's Status Means
+
+You'll see one of these next to each order:
+
+- **Processing** — we got your order and are making or packing it
+- **Shipped** — it's on the way; tracking is available
+- **Delivered** — the carrier marked it delivered
+- **Cancelled** — the order didn't go through, and your card wasn't charged (or was refunded)
+
+For what to do once an order ships, see [When Your Order Ships](when-your-order-ships.md).
+
+## Need Help?
+
+If an old order is missing or the status doesn't look right:
+
+- [Contact us](https://extrachill.com/contact/) with your order number
+- Ask in the [Tech Support forum](https://community.extrachill.com/r/tech-support)

--- a/drafts/shop/when-your-order-ships.md
+++ b/drafts/shop/when-your-order-ships.md
@@ -1,0 +1,58 @@
+# When Your Order Ships
+
+After you place an order, the next thing you want to know is when it'll arrive. Here's what to expect.
+
+## Two Stages: Production, Then Shipping
+
+Most items in the Extra Chill Shop fall into one of two groups:
+
+- **Made-to-order items** — printed or assembled after you buy them. These take **2 to 7 business days** to produce before they leave for you.
+- **In-stock items** — already on the shelf. These ship faster, often within a day or two.
+
+Each item's page tells you which kind it is. Production time is separate from shipping time, so the total wait is **production time + shipping time**.
+
+## You'll Get a Tracking Number
+
+Once your order leaves, you'll get an email with a tracking number. Click the link in that email to see where your package is and when it's expected to arrive.
+
+If it's been more than a week since you ordered an in-stock item, or more than two weeks since you ordered a made-to-order item, and you still haven't gotten a tracking email, [contact us](https://extrachill.com/contact/) and we'll look into it.
+
+![Screenshot: example shipping confirmation email with the tracking link]
+
+## Where We Ship
+
+We ship across the United States. Stickers ship free. Other in-stock Extra Chill merch ships at a flat rate of **$3.50**. For items from artists or larger orders, the cost is calculated at checkout based on your address.
+
+If you're outside the US, check the item's page or [contact us](https://extrachill.com/contact/) before ordering — international shipping isn't available on every item.
+
+## Make Sure Your Address Is Right
+
+Before you confirm checkout, double-check the shipping address. A wrong address can mean:
+
+- A delay while the package gets sent back to us
+- Extra shipping fees to send it out again
+- A package that's gone for good
+
+If you're in the US and not sure your address is formatted correctly, look it up on your local postal service's website before you check out.
+
+## Undeliverable Packages
+
+If a package can't be delivered and gets returned to us, we'll hold it for **28 days** while we try to reach you. After that, we may not be able to ship it again without a new order.
+
+## Lost or "Delivered but Missing"
+
+If tracking says your package was delivered but you don't have it:
+
+1. Check with neighbors and around your front door
+2. Look for a notice from your local post office
+3. Check any alternate delivery spots (back door, side gate, building mailroom)
+4. [Contact us](https://extrachill.com/contact/) if it still hasn't turned up
+
+We can't replace packages that were marked as delivered by the carrier, but we will help you investigate. If a package was never marked as delivered and seems lost, we'll look into each one individually.
+
+## Need Help?
+
+For shipping questions or to report a problem with an order:
+
+- [Contact us](https://extrachill.com/contact/)
+- Ask in the [Tech Support forum](https://community.extrachill.com/r/tech-support)


### PR DESCRIPTION
Refs #12, follows writing rules from #6.

## Summary

Six end-user help article drafts covering the shop platform, dropped in `drafts/shop/` for review before promotion to `ec_docs/shop/`.

| File | Words | Topic |
|------|-------|-------|
| `find-and-buy-something.md` | 455 | browsing, sort/filter, cart, checkout flow |
| `when-your-order-ships.md` | 488 | production vs shipping time, tracking, undeliverable, lost packages |
| `returns-and-refunds.md` | 469 | what's eligible, 30-day window, how to start a return, refund timing |
| `buying-merch-from-your-favorite-artists.md` | 448 | marketplace pitch, what's same/different, cross-links artist platform |
| `paying.md` | 449 | payment methods, security, guest checkout, charge timing, sales tax |
| `see-your-past-orders.md` | 414 | logged-in vs guest, order statuses, claiming guest orders |

All articles:
- 200–500 words ✓
- H1 title, no frontmatter ✓
- Screenshot placeholders where they help ✓
- "Need help?" footer ✓
- Cross-link each other where relevant
- Cross-link artist platform docs from the merch article

## Source of truth

Anchored to the live shop and the published [Shipping & Returns Policy](https://shop.extrachill.com/shipping-and-returns/). Concrete numbers (2–7 business day production, $3.50 in-stock flat shipping, free sticker shipping, 30-day damage window, 28-day undeliverable hold, up to 10 business day refund visibility) come from there.

## Hard rules audit

- No platform names: no WooCommerce, Stripe, USPS, etc. The policy page links the USPS lookup tool — I generalized to "your local postal service's website" to stay inside the rules in #6.
- No admin / shop manager workflows
- "Order" not "transaction", "you" not "customer" — verified with grep
- Returns article is honest about timing: 30 days, up to 10 business days for refund visibility, made-to-order can't be cancelled, change-of-mind not accepted
- Sixth-grade reading level pass

## Open questions for @chubes

A few things I had to make plausible guesses on. Flag any that need correcting before promotion:

1. **Payment methods.** I listed Visa/Mastercard/Amex/Discover plus Apple Pay / Google Pay. Confirm Apple Pay / Google Pay are actually wired up at checkout — if not, I'll strip those.
2. **Guest checkout.** I asserted you can check out as a guest. The shop currently shows "under construction" on the cart/product pages so I couldn't verify the live checkout. Confirm guest checkout is enabled.
3. **Claim-past-guest-orders.** The "guest orders attach to a new account using the same email" is standard behavior, but confirm it's actually how it works on the shop.
4. **Refund window.** I wrote "up to 10 business days for the refund to show up" as a safe upper bound. If you have a tighter real number, I'll use it.
5. **Marketplace timing.** The shop home page says it's "under construction" with the artist marketplace pitch. Articles describe the marketplace as if live. Once promoted to `ec_docs/shop/`, we'll want to align this with launch state — flag if drafts should sit until launch.
6. **International shipping.** Article says "check the item's page or contact us before ordering" — confirm whether international is currently supported at all and if there's a list of countries.
7. **Order status labels.** I used Processing / Shipped / Delivered / Cancelled. Confirm these match what buyers actually see.

## Out of scope

- No code changes outside `drafts/`
- No version bump, no CHANGELOG entry
- Promotion to `ec_docs/shop/` happens in a follow-up PR after review