### PR TITLE
docs(drafts): artist platform help articles (refs #16)

### DIFF
--- a/drafts/artist-platform/let-fans-follow-you.md
+++ b/drafts/artist-platform/let-fans-follow-you.md
@@ -1,0 +1,49 @@
+# Let fans follow you
+
+Following is the easiest way for fans to keep up with your music on Extra Chill. When someone follows you, the things you put out land in front of them automatically — without them having to remember to come check.
+
+## How fans follow you
+
+Anyone signed in to Extra Chill can follow you. They open your artist page and click the **Follow** button near the top. That's it — they're now following you, and they can unfollow any time by clicking the same button again.
+
+![Screenshot: artist page with the Follow button near the top](screenshot-needed-1.png)
+
+You don't have to approve followers. The button is open to everyone, the same way following works on most music sites.
+
+## What followers see
+
+When a fan follows you, your activity starts showing up in the places they already spend time on Extra Chill. That includes:
+
+- **Their feed in the community** — when you post something, share music, or get written about
+- **Their notifications** — for the things they've asked to be told about
+- **Email updates** — if they've turned those on for the artists they follow
+
+The point is simple: a fan who follows you doesn't have to go looking for what you're doing. Extra Chill brings it to them.
+
+## Where notifications go
+
+Notifications show up in the bell icon at the top of every Extra Chill page. Fans can open it any time to see what's happened recently from the artists they follow. They can also choose how often they want to hear about it, and what kinds of things they want to be told about.
+
+For more on how that side works for your fans, see the [notifications article](https://docs.extrachill.com/community/notifications-system/).
+
+![Screenshot: notifications panel showing recent updates from a followed artist](screenshot-needed-2.png)
+
+## Why followers matter
+
+Followers are the people most likely to listen to your next release, share your shows, and show up. A small but engaged following on Extra Chill is worth more than a big number that never hears from you, so the best thing you can do is keep your page active. Update your bio when something changes, post when there's news, and share your music in the community where your followers will see it.
+
+## How to grow your following
+
+A few simple things make a real difference:
+
+- **Share your Extra Chill page** with your fans on the platforms they already use
+- **Post in the community** so other music fans can find you
+- **Cover your shows and releases** on your page so there's always a reason to come back
+- **Engage with other artists' work** — fans who like an artist often check out who that artist is into
+
+## Need help?
+
+If you have questions about followers or how fans hear from you:
+
+- [Contact us](https://extrachill.com/contact/)
+- Ask in the [Tech Support forum](https://community.extrachill.com/r/tech-support)

--- a/drafts/artist-platform/sell-your-merch-on-extra-chill.md
+++ b/drafts/artist-platform/sell-your-merch-on-extra-chill.md
@@ -1,0 +1,56 @@
+# Sell your merch on Extra Chill
+
+If you're an artist on Extra Chill, you can sell your shirts, records, stickers, and anything else right alongside the rest of our shop. Fans buy from you the same way they'd buy anything else on the site, and the money goes straight to you.
+
+## What you'll need
+
+Before you list your first item, get these ready:
+
+- **Photos of your merch** — clear shots on a clean background work best
+- **A price** for each item
+- **The address you'll ship from** — this is just for postage, fans don't see it
+- **A way to get paid** — you'll connect a payout account once during setup
+
+You only have to set the address and the payout account up once. After that, listing new items is quick.
+
+## Open your shop area
+
+Sign in at [artist.extrachill.com](https://artist.extrachill.com) and go to the manage shop area. If you look after more than one artist, pick the right one from the dropdown at the top.
+
+![Screenshot: manage shop area with tabs for products, orders, shipping and payments](screenshot-needed-1.png)
+
+You'll see a few tabs:
+
+- **Products** — your items for sale
+- **Orders** — what fans have bought
+- **Shipping** — where you'll ship from
+- **Payments** — how you get paid
+
+Fill out the shipping and payments tabs first. Until those are set up, you can save items as drafts but you can't put them on sale.
+
+## Add an item
+
+On the products tab, click **Add product** and fill in:
+
+- **Name** — what fans will see at the top of the listing
+- **Price** — what it costs
+- **Description** — sizes, materials, anything fans should know
+- **Photos** — up to five, with the first one used as the main image
+- **Sizes and stock** — if your item comes in different sizes, list each one and how many you have
+
+When everything looks right, set the item to **Published** and save. It'll show up in the shop right away.
+
+![Screenshot: add product form with name, price, photos and size fields](screenshot-needed-2.png)
+
+## When someone buys
+
+You'll get an email any time a fan buys something. Head to the **Orders** tab to see what they ordered and where to ship it. From there you can print a shipping label, mark the order as shipped once it's on its way, or refund the order if something goes wrong.
+
+The fan side of an order — paying, shipping times, returns — works the same as anything else in our shop. Take a look at the shop articles for how that side feels to your fans.
+
+## Need help?
+
+If you have questions about selling on Extra Chill:
+
+- [Contact us](https://extrachill.com/contact/)
+- Ask in the [Tech Support forum](https://community.extrachill.com/r/tech-support)

--- a/drafts/artist-platform/set-up-your-artist-page.md
+++ b/drafts/artist-platform/set-up-your-artist-page.md
@@ -1,0 +1,47 @@
+# Set up your artist page
+
+Your artist page is your home on Extra Chill — a place fans can find you, learn about your music, and follow what you're up to. Setting it up takes a few minutes and you can keep adding to it whenever you want.
+
+## Open your artist page
+
+Sign in at [artist.extrachill.com](https://artist.extrachill.com) and head to the manage area. If you look after more than one artist, pick the one you want to work on from the dropdown at the top of the page.
+
+![Screenshot: artist manage area with the artist picker at the top](screenshot-needed-1.png)
+
+You'll see a few tabs. Most of what fans see lives on the first tab.
+
+## Add the basics
+
+Start with the things every visitor will look for:
+
+- **Your artist or band name** — this is the name that shows up everywhere on Extra Chill, so spell it the way you want fans to see it
+- **A profile photo** — a square image works best, since it's used in lots of places at different sizes
+- **A header image** — a wider banner that runs across the top of your page
+- **Where you're based** — your city or region, so local fans can find you
+- **Your sound** — a short genre or style, like "indie folk" or "hip-hop"
+- **A short bio** — a few sentences about who you are and what your music is about
+
+You don't have to fill everything out at once. Save what you have and come back later to round it out.
+
+![Screenshot: artist info form with name, photo, header image and bio fields](screenshot-needed-2.png)
+
+## Save your changes
+
+Hit the **Save** button at the top of the page when you're done. You'll see a small confirmation that your changes went through.
+
+To see how your page looks to fans, click **View profile**. Anything you save shows up on your public page right away.
+
+## Bring your team in
+
+If a manager, bandmate, or friend helps run your stuff, you can invite them to share access. They'll be able to update the page just like you can. Take a look at the article on artist access and permissions for how that works.
+
+## Keep it fresh
+
+The artists who get the most out of Extra Chill keep their page current. Update your bio when you put out new music, swap your header image when you have new photos, and check in once in a while to make sure everything still feels like you.
+
+## Need help?
+
+If you get stuck setting up your artist page:
+
+- [Contact us](https://extrachill.com/contact/)
+- Ask in the [Tech Support forum](https://community.extrachill.com/r/tech-support)

--- a/drafts/artist-platform/take-ownership-of-your-artist-page.md
+++ b/drafts/artist-platform/take-ownership-of-your-artist-page.md
@@ -1,0 +1,40 @@
+# Take ownership of your artist page
+
+Sometimes a page already exists for you on Extra Chill before you ever sign up. A fan might have started it, or we might have put one together while writing about you. If there's already a page for your music, you can take it over and run it yourself.
+
+## How to know if a page already exists
+
+Search Extra Chill for your artist or band name. If you find a page that's about you but isn't being run by anyone on your team, that's the one to claim.
+
+![Screenshot: search results showing an unclaimed artist page](screenshot-needed-1.png)
+
+If nothing comes up, no page exists yet. In that case, just [set up your artist page](set-up-your-artist-page.md) from scratch — you don't need to claim anything.
+
+## Start a claim
+
+Open the page you want to take over and look for the option to claim it. Sign in to your Extra Chill account first, or make one if you don't have one yet.
+
+Tell us a little about who you are and how you're connected to the artist. The more clearly you can show that you're really part of the project, the smoother this goes. We may ask for one or two extra things to back that up.
+
+![Screenshot: claim form on an artist page](screenshot-needed-2.png)
+
+## What happens after you submit
+
+Someone on our team takes a look at every claim by hand. We'll get back to you by email when we've made a decision. Most claims are sorted out within a few days.
+
+We do this to protect artists. Pages on Extra Chill belong to the people who actually make the music, and we'd rather take a beat to get it right than hand a page to the wrong person. If we need anything else from you, we'll just ask.
+
+## Once your claim goes through
+
+When we approve your claim, the page is yours. You'll be able to update the photo, the bio, and everything else on it. From there, the page works exactly like one you set up yourself — head over to [set up your artist page](set-up-your-artist-page.md) for what to fill in, and bring your team in if other people help run your stuff.
+
+## If your claim doesn't go through
+
+If we can't confirm the connection, we'll email you to explain. You're welcome to reply with more information and we'll take another look. We're not trying to keep anyone out — we just want to make sure pages end up with the right people.
+
+## Need help?
+
+If you have questions about claiming a page or you're not sure whether a page is already out there:
+
+- [Contact us](https://extrachill.com/contact/)
+- Ask in the [Tech Support forum](https://community.extrachill.com/r/tech-support)


### PR DESCRIPTION
## Summary

Adds 4 draft help articles for the artist platform topic gaps from #16. All drafts only — they live in `drafts/artist-platform/` and are not synced to the live docs site.

## Articles

- **`set-up-your-artist-page.md`** — basics of filling out an artist page (rewrite of orphan)
- **`sell-your-merch-on-extra-chill.md`** — artist-side handoff to the shop articles (#12); covers listing items, getting paid, fulfilling orders without duplicating the customer-facing shop coverage
- **`take-ownership-of-your-artist-page.md`** — claim flow; deliberately vague about what we check on our end so we don't telegraph anti-fraud measures
- **`let-fans-follow-you.md`** — how follows work, what fans see, where notifications land; cross-links to the existing [Notifications System](https://docs.extrachill.com/community/notifications-system/) article

## Raw input used

Per #16, the two orphan markdown files were used as raw input and rewritten under the new writing rules:

- `ec_docs/artist/managing-your-artist-profile.md` → `set-up-your-artist-page.md`
- `ec_docs/artist/creating-your-artist-merch-store.md` → `sell-your-merch-on-extra-chill.md`

The orphan files are left in place. Their fate is a separate concern in #7.

## Writing rules check

Each article was reviewed against the #6 rules:

- End-user only — no plugin, tool, vendor, or system names
- No technical jargon (no checkout software, payment processor, shipping carrier, sign-in vendor, etc.)
- Sixth-grade reading level, short sentences
- Benefit-focused intros
- Screenshot placeholders included
- "Need help?" footer on every article
- Word count: 443–478 words each (within 200–500 range)

The verification article describes the **process the artist follows**, not what we check for on our end.

## Refs

Refs #16, #6, #12

@chubes