### PR TITLE
docs(drafts): events calendar help articles (refs #18)

### DIFF
--- a/drafts/events-calendar/festivals.md
+++ b/drafts/events-calendar/festivals.md
@@ -1,0 +1,57 @@
+# Festivals
+
+Festivals get their own pages on Extra Chill. A festival is really a bunch of shows wrapped into one event — multiple days, multiple stages, a full lineup. The festival page pulls all of that together.
+
+## What's Different About a Festival
+
+A regular show is one band — or a few bands on a bill — playing one venue on one night. A festival is bigger:
+
+- It usually runs over multiple days
+- It often happens across more than one stage or venue
+- It has a full lineup of artists, sometimes dozens or more
+- It's its own brand, not just a date on a venue's calendar
+
+So instead of cramming all that into one event listing, festivals get their own dedicated page.
+
+![Screenshot: a festival page header showing the festival name and dates]
+
+## Open a Festival Page
+
+A few ways to find one:
+
+- Click a festival name on any related event or article
+- Filter the events calendar by festival and pick one from the list
+- Go straight to a festival URL if you've bookmarked it
+
+## What's on a Festival Page
+
+A festival page is your home base for that festival. You'll typically find:
+
+- Name, dates, and location
+- The lineup of artists playing
+- Each day or set listed as its own event, when we have details
+- Background info or feature articles, when we've written about it
+- Links to past coverage
+
+If the festival has a big lineup, those artists are linked to their own pages on Extra Chill, so you can dig into anyone you don't know yet.
+
+![Screenshot: a festival page showing the lineup and individual day listings]
+
+## Plan Your Days
+
+Because a festival can run for several days, it's worth checking the full schedule on the festival page rather than just one day. You can mark yourself as going to specific days, save them to your phone calendar, and use the page to keep track of what overlaps and what doesn't.
+
+For more on how going and calendar export work, see [Say You're Going to a Show](say-youre-going-to-a-show.md).
+
+## Lineups and Artists
+
+Festivals usually announce their lineups in waves — headliners first, then the rest of the bill, then last-minute additions. The page gets updated as new artists are confirmed, so it's worth checking back.
+
+If you've found an artist you like through Extra Chill, their profile lists any festivals they're booked at — another way to discover festivals.
+
+## Need Help?
+
+If a festival page is missing information, or a festival you know about isn't on the site:
+
+- [Contact us](https://extrachill.com/contact/)
+- Ask in the [Tech Support forum](https://community.extrachill.com/r/tech-support)

--- a/drafts/events-calendar/find-shows-in-your-city.md
+++ b/drafts/events-calendar/find-shows-in-your-city.md
@@ -1,0 +1,44 @@
+# Find Shows in Your City
+
+The Extra Chill events calendar covers shows in close to 200 cities. The fastest way to make it useful is to narrow it down to where you actually live.
+
+## Pick Your City
+
+Visit [events.extrachill.com](https://events.extrachill.com). Right at the top of the page you'll see a list of cities, each with a number next to it showing how many upcoming shows are on the books there.
+
+Click your city. The calendar reloads to show only shows in that city, and the page becomes your home for local listings.
+
+![Screenshot: the city list on the events calendar homepage]
+
+If your city is big enough to have its own scene, you'll usually find it in the list. The cities are ordered by how many shows are coming up, so the busiest places are at the top.
+
+## Use Filters Instead
+
+If you don't see your city in the quick-pick list, or you want to combine your city with other things — say, a specific venue or a band — open the **Filter** panel on the calendar page. You can pick a location from there along with any other filter you want to apply.
+
+For more on filters in general, see [Using Calendar Filters](using-calendar-filters.md).
+
+## Switching Cities
+
+Once you're on a city page, the URL is bookmarkable — save it and you can come back to your local calendar anytime.
+
+To switch to a different city, click the city name in the page header to go back to the full list, or use the location filter to swap to a new one. You can keep multiple cities bookmarked if you split your time, travel a lot, or want to plan around a trip.
+
+![Screenshot: the location filter showing several city options]
+
+## Following a City
+
+If you want updates about what's happening in a city, the best move is to sign up for the **Sunday Chill** newsletter. The weekly show roundup highlights what's worth catching, with cities that have deep coverage — like Charleston and Austin — getting their own picks. See [Subscribing to the Sunday Chill](../newsletter/subscribing-to-the-sunday-chill.md) for how to sign up.
+
+You can also bookmark your city's page and check it whenever you're planning the week. New shows get added all the time, so it's worth a look every few days.
+
+## A Note on Coverage
+
+Some cities have thousands of upcoming shows. Others have a smaller list. Coverage keeps growing — if your city is light, check back. It's getting better all the time.
+
+## Need Help?
+
+If you can't find your city, or filters aren't behaving:
+
+- [Contact us](https://extrachill.com/contact/)
+- Ask in the [Tech Support forum](https://community.extrachill.com/r/tech-support)

--- a/drafts/events-calendar/look-up-a-venue.md
+++ b/drafts/events-calendar/look-up-a-venue.md
@@ -1,0 +1,49 @@
+# Look Up a Venue
+
+Every venue on Extra Chill has its own page — a single spot where you can see everything coming up at that room. It's the easiest way to find out what's on the schedule at your favorite spot, or to check what a venue is like before you head out to a show there.
+
+## Open a Venue Page
+
+There are a few ways to land on a venue page:
+
+- Click a venue name on any event page — it's usually right under the show title
+- Filter the calendar by venue and pick one from the list
+- Go straight to a venue URL if you've bookmarked it
+
+![Screenshot: an event page with the venue name highlighted as a link]
+
+## What's on a Venue Page
+
+A venue page shows you the basics about the place plus every upcoming show on the calendar there.
+
+You'll typically see:
+
+- The venue's name and city
+- Address and a map, when we have it
+- Every confirmed upcoming show, sorted by date
+- Past shows that have already happened, further down the page
+
+It's the same calendar view you're used to, but already filtered to that one room. No need to apply anything yourself.
+
+![Screenshot: a venue page showing a list of upcoming shows]
+
+## Find Every Upcoming Show There
+
+The list of upcoming shows is the main reason most people visit a venue page. Scroll the list, click any show that looks interesting, and you'll be on the event page where you can mark yourself as going, save the show to your phone calendar, or grab tickets.
+
+If a venue has a lot of shows coming up, you can scroll through the full list to plan further out. Big rooms often have shows booked months in advance.
+
+## Bookmark Your Favorites
+
+If there are venues you go to all the time, bookmark their pages. That way checking the schedule is one click instead of a search. This is especially handy for smaller rooms that don't post their full calendar anywhere obvious.
+
+## When a Show Isn't Listed
+
+Sometimes a venue has a show on its own website that hasn't made it to Extra Chill yet. If you know about a show that's missing, you can submit it — see [How to Submit an Event](submitting-an-event.md) for the form. Submissions get reviewed and added to the calendar within a few days.
+
+## Need Help?
+
+If a venue page is missing information, or you can't find a venue you know exists:
+
+- [Contact us](https://extrachill.com/contact/)
+- Ask in the [Tech Support forum](https://community.extrachill.com/r/tech-support)

--- a/drafts/events-calendar/say-youre-going-to-a-show.md
+++ b/drafts/events-calendar/say-youre-going-to-a-show.md
@@ -1,0 +1,44 @@
+# Say You're Going to a Show
+
+Found a show you want to see? You can mark yourself as going right from the event page. It's a quick way to keep track of what's on your schedule, let friends know what you're up to, and make sure the show actually shows up on your phone's calendar.
+
+## Mark Yourself as Going
+
+Open any show on [events.extrachill.com](https://events.extrachill.com). On the event page, click the **Going** button.
+
+You'll need to be logged in to your Extra Chill account. If you're not logged in yet, you'll be prompted to sign in or create an account. It's free and takes about a minute.
+
+![Screenshot: an event page with the Going button visible]
+
+Once you've clicked Going, the button updates to show you're in. Click it again to change your mind — you can take yourself off the list anytime.
+
+## Who Else Sees It
+
+When you mark yourself as going, your name shows up on the event page along with everyone else who's planning to be there. This is handy for a few reasons:
+
+- Your friends can see which shows you're hitting
+- You can see who else from the community is going to a show before you commit
+- Artists and venues get a feel for who's interested
+
+If you'd rather keep your plans private, just don't click Going — you can still bookmark the page or save the event to your phone calendar without telling anyone.
+
+## Add the Show to Your Phone Calendar
+
+Every event page has an option to send the show straight to your phone's calendar. Click the calendar icon or the **Add to Calendar** link on the event page.
+
+![Screenshot: the Add to Calendar option on an event page]
+
+The show will appear in whatever calendar app you use — the one on your iPhone, Google Calendar, Outlook, whatever. You'll get the date, the start time, the venue name, and the address all filled in for you. Set a reminder for an hour before doors open and you're good.
+
+This works whether or not you've marked yourself as going. They're separate — going is the social part, the calendar export is just for you.
+
+## Changing Your Plans
+
+Life happens. If you can't make it after all, just open the event again and click the Going button to remove yourself. The show will still be on your phone calendar, though, so you may want to delete it from there too.
+
+## Need Help?
+
+If the Going button isn't working, or your calendar export looks off:
+
+- [Contact us](https://extrachill.com/contact/)
+- Ask in the [Tech Support forum](https://community.extrachill.com/r/tech-support)

--- a/drafts/events-calendar/the-weekly-show-roundup.md
+++ b/drafts/events-calendar/the-weekly-show-roundup.md
@@ -1,0 +1,45 @@
+# The Weekly Show Roundup
+
+Every week, Extra Chill picks the shows worth knowing about in a few different cities and writes them up in one place. It's a quick read on what's happening, who's playing, and where to be — without having to dig through a calendar.
+
+## What It Is
+
+The roundup is a short post that runs on the [Extra Chill blog](https://extrachill.com) at the start of the week. It walks through the shows we think are worth your attention, with a sentence or two on each — who the band is, why we like them, and where to catch them.
+
+It's not the full calendar. It's a curated short list. The point is to give you a few solid options instead of an overwhelming wall of dates.
+
+![Screenshot: a recent weekly roundup post on extrachill.com]
+
+## Which Cities Get a Roundup
+
+The roundup focuses on cities where Extra Chill has the deepest coverage — Charleston first, since that's our home base, and Austin, where we've been spending more time. As coverage in other cities grows, you'll start seeing roundups for those places too.
+
+If your city isn't covered yet, you can still find every show on it through the [events calendar](https://events.extrachill.com) and filter to your city. You don't need a roundup to find shows — the roundup is just our take on what stands out.
+
+## How We Pick the Shows
+
+We're looking for the stuff we'd actually go see. That usually means:
+
+- Local bands we've been following
+- Touring acts hitting town that fans of independent music would care about
+- Smaller rooms over big venues, when the bill is interesting
+- One-off events, residencies, and anything else with a story behind it
+
+It's a curated pick, not a complete list. If a show isn't in the roundup, it doesn't mean it's not worth going to — it just means we had to keep the list short.
+
+## Where to Read It
+
+You can find the roundup three ways:
+
+- On the [Extra Chill blog](https://extrachill.com), pinned near the top of the homepage at the start of the week
+- In the **Sunday Chill** email newsletter, which lands in your inbox every Sunday morning with the week's roundup baked in
+- Shared on Extra Chill's social channels through the week
+
+If you want it delivered, signing up for the newsletter is the easy move. See [Subscribing to the Sunday Chill](../newsletter/subscribing-to-the-sunday-chill.md) for how to get on the list.
+
+## Need Help?
+
+If you can't find the latest roundup, or the newsletter isn't showing up:
+
+- [Contact us](https://extrachill.com/contact/)
+- Ask in the [Tech Support forum](https://community.extrachill.com/r/tech-support)


### PR DESCRIPTION
Drafts for the events calendar topic gaps in #18. Five user-facing help articles, each 200-450 words, end-user voice, screenshot placeholders, Need help footer.

## Articles

- **Say You're Going to a Show** — marking yourself as attending, who sees it, sending the show to your phone calendar
- **The Weekly Show Roundup** — what it is, which cities get coverage, where to read it (cross-links to the newsletter article when it lands)
- **Find Shows in Your City** — picking a city from the calendar, switching cities, following along via the newsletter
- **Look Up a Venue** — what a venue page shows, finding every upcoming show there, bookmarking favorites
- **Festivals** — how festival pages work, what's on them, how a festival differs from a regular show

## Writing rule check

- No internal product, plugin, taxonomy, or service names
- No mention of how events get into the system
- Calendar export described as outcome ("the show appears in your phone calendar"), no protocol names
- "Say you're going" used in place of "RSVP" in headings/copy where it reads better
- Festival article makes the multi-day/multi-stage/lineup distinction up front
- Sixth-grade reading level, short paragraphs, screenshot placeholders throughout

## Cross-links

- The Weekly Show Roundup → Subscribing to the Sunday Chill (newsletter drafts, when published)
- Find Shows in Your City → Using Calendar Filters (existing) + newsletter
- Look Up a Venue → How to Submit an Event (existing)
- Festivals → Say You're Going to a Show

## Out of scope

No code, no version bumps, no touching anything outside `drafts/events-calendar/`.

cc @chubes — refs #18, #6