### PR TITLE
docs(drafts): community help articles (refs #17)

### DIFF
--- a/drafts/community/block-someone.md
+++ b/drafts/community/block-someone.md
@@ -1,0 +1,28 @@
+# Block Someone
+
+Sometimes another member is making the forums less fun for you — maybe they're picking fights, maybe they're just someone whose posts you'd rather not see. You'd like a way to mute them.
+
+Here's the honest version of where we are with that today.
+
+## We don't have a block button yet
+
+Extra Chill Community doesn't have a built-in block feature right now. There's no button on someone's profile that hides their posts from you, and there's no setting that stops someone from replying to you or sending you messages.
+
+We know that's a real gap. It's on our list to build.
+
+## What you can do in the meantime
+
+- **Stop following them.** If you're following someone and seeing their activity in your feed, go to their profile and click "Unfollow." That cleans up your own feed even if their posts still show up in forum threads.
+- **Skip the thread.** If a specific person is dominating one conversation, you can just stop opening that topic. The forum index won't push it at you if you don't click in.
+- **Mute notifications from a thread.** If you're in a topic where someone keeps replying to you and you want it to stop pinging your bell icon, stop replying — once you're not active in the topic, the back-and-forth notifications taper off.
+- **Report them if they're breaking the rules.** Blocking is for personal preference. If someone is harassing you, doing the [report flow](report-a-post-or-person.md) is the right call — we'll handle it on our end.
+
+## What blocking will do when we ship it
+
+When we build the block feature, here's what we're aiming for: their posts hidden from your view, no notifications from them, and they can't tag you to ping your bell. We'll update this article when it's live.
+
+[SCREENSHOT: A user profile page showing the Follow / Unfollow button as the current closest workaround]
+
+## Need help?
+
+If someone is genuinely making the community unsafe for you and "skip the thread" isn't enough, please [contact us](https://extrachill.com/contact/) directly. We take that seriously and we'd rather know.

--- a/drafts/community/community-ground-rules.md
+++ b/drafts/community/community-ground-rules.md
@@ -1,0 +1,32 @@
+# Community Ground Rules
+
+Extra Chill Community is a hangout for music people. Fans, artists, label folks, show-runners, anyone who cares about independent music. The vibe is friendly, opinionated, and loose — like talking music in a bar, not a corporate Slack.
+
+These are the ground rules. They are short on purpose.
+
+## What we want
+
+- **Talk about music.** Bands you love, shows you went to, records you found, scenes you live in. The good stuff.
+- **Have opinions.** "This album is a let-down" is fine. "I think this band is overrated and here's why" is fine. Heat is welcome — heat with a reason behind it is even better.
+- **Help each other out.** Someone asks for a band recommendation, throw them a few. Someone is touring through your city, tell them the venue to play and the bar to drink at after.
+- **Promote your music in the right place.** If you're an artist, share your stuff in the music sharing forum or in a discussion where it actually fits. Don't drop links in unrelated threads.
+
+## What we don't want
+
+- **Spam.** Drive-by promo, affiliate dumps, link farms — gone.
+- **Personal attacks.** Disagree with the take, not the person. Calling someone a name ends the conversation, not the argument.
+- **Hate speech.** Racism, homophobia, transphobia, all of that — there's no version of it that's welcome here. We will remove it without a long explanation.
+- **Doxxing or harassment.** Don't post other people's private info. Don't follow someone around the forums to start fights.
+- **Off-topic political slap-fights.** This isn't the place. Music can be political — go for it. National election shouting matches — not here.
+
+## When something goes wrong
+
+If you see a post or a person breaking these rules, you can [report it](report-a-post-or-person.md) or [block the person](block-someone.md) so you stop seeing their stuff.
+
+We read every report. We don't moderate based on who's complaining loudest — we moderate based on the rules.
+
+[SCREENSHOT: Community homepage showing recent forum activity and the friendly tone of real discussions]
+
+## Need help?
+
+If something feels off and you're not sure what to do, head to the [Tech Support forum](https://community.extrachill.com/r/tech-support) or the [contact page](https://extrachill.com/contact/) and we'll take a look.

--- a/drafts/community/find-something-in-the-forums.md
+++ b/drafts/community/find-something-in-the-forums.md
@@ -1,0 +1,29 @@
+# Find Something in the Forums
+
+The community has thousands of posts going back years. There's a good chance the band you're about to ask about, the venue you want to know about, or the rant you half-remember reading is already in there. Here's how to find it.
+
+## Use the search button
+
+Look in the top right corner of any community page for the magnifying glass icon. Click it, type a word or two, and hit enter. The forum will show you every topic and reply that mentions what you searched for.
+
+You don't need to log in to search.
+
+## Tips that actually help
+
+- **One or two strong words beats a long phrase.** Searching for "Pour House" finds more than searching for "shows at the Pour House this fall."
+- **Use a band's name, not a song's.** Band names show up in titles, song names mostly show up in replies. You'll get more hits with the band name.
+- **Try the venue or the city.** "Charleston," "Royal American," "Music Farm" — these pull up everything tied to that place over the years.
+- **Spell it the way the band spells it.** If they use weird capitalization or punctuation, search the way it's actually written.
+- **Try a few wordings.** "Tour" and "show" and "live" are all words people use for the same thing. If one search comes up empty, try another angle.
+
+## Browse by forum if search isn't doing it
+
+If you know the rough area but not the exact words, go straight to the forum that fits and scroll. The Local Scenes forum has city sub-forums for Charleston, Austin, and Philadelphia. Music Discussion is the biggest catch-all.
+
+You can also click on a member's profile to see every topic and reply they've ever posted, which is great for catching up on a writer or artist you trust.
+
+[SCREENSHOT: Search bar opened in the community header with sample query and results below]
+
+## Need help?
+
+Searching only the community forums and want to find something across the whole Extra Chill site instead? Use the search button on the main [extrachill.com](https://extrachill.com) homepage — that searches the blog, the events calendar, and more in one shot.

--- a/drafts/community/reply-quote-and-tag-people.md
+++ b/drafts/community/reply-quote-and-tag-people.md
@@ -1,0 +1,39 @@
+# Reply, Quote, and Tag People
+
+Forum conversations are easier to follow when people reply to specific posts, quote what they're responding to, and tag the person they're talking about. Here's how each of those works on Extra Chill Community.
+
+## Reply to a topic vs. reply to a specific post
+
+Every topic has a reply box at the bottom — that's for replying to the topic itself. Use it when you're adding to the general discussion.
+
+To reply to one specific post inside the topic, look for the "Reply" link on that post. The form will say "Reply to @username" so you know it's threaded. This keeps long topics readable — side conversations can happen in the same thread without people losing the plot.
+
+## Quoting someone
+
+There isn't a one-click "quote this" button on posts. To quote someone:
+
+1. Copy the part of their post you want to respond to.
+2. Open your reply.
+3. Use the quote block in the editor — it's the icon that looks like a speech mark or quotation mark — and paste the text in.
+4. Write your response below or above the quote.
+
+Quoting works best when you keep it short. Pull the one sentence you're reacting to, not the whole post.
+
+## Tagging someone with `@`
+
+Type `@` followed by their username — for example `@chubes` — and that person gets a notification with a link to your post. They'll see it in their notifications bell next time they log in.
+
+A few things to know:
+
+- Use the username, not the display name. If a member's display name is "Jane from Austin" but their username is `jane`, you tag them as `@jane`.
+- Tagging only works for real, active members.
+- You can tag more than one person in the same post — `@chubes @qrisg` both get pinged.
+- Tagging yourself doesn't notify you (we checked).
+
+Use tags when you want a specific person to see your post. Don't use them as decoration.
+
+[SCREENSHOT: Reply form open on a topic, with "Reply to @username" header, a quote block, and an @-mention being typed]
+
+## Need help?
+
+Tagged someone and they say they didn't get a notification? Make sure you used their username (visible on their profile URL), not their display name. Still stuck? Drop a note in [Tech Support](https://community.extrachill.com/r/tech-support).

--- a/drafts/community/report-a-post-or-person.md
+++ b/drafts/community/report-a-post-or-person.md
@@ -1,0 +1,34 @@
+# Report a Post or a Person
+
+If you see something on Extra Chill Community that breaks the [ground rules](community-ground-rules.md) — spam, harassment, hate speech, someone using the forums to attack another member — let us know. We read every report.
+
+## What you can report
+
+- A post or reply that breaks the rules
+- A person who keeps breaking the rules across multiple posts
+- Someone harassing you or another member
+- Spam, scams, or bot accounts
+
+## How to report
+
+Right now we don't have a one-click report button on every post. To flag something:
+
+1. Head to the [contact page](https://extrachill.com/contact/) and send us a quick note. A link to the post and one sentence about what's wrong is plenty — you don't need a long write-up.
+2. Or post in the [Tech Support forum](https://community.extrachill.com/r/tech-support) if it's something you're comfortable raising publicly.
+3. Or tag a moderator in a reply with `@chubes` if it's something obvious like spam in a thread.
+
+If the situation is urgent — someone is sharing private info about you, posting threats, or running an active harassment campaign — use the contact form and say "urgent" in the subject. We'll see it faster.
+
+## What happens after you report
+
+A real person on our team reads it. We look at the post, the person's history, and the context. Then we decide what to do — that might be a warning, removing the post, or banning the account.
+
+We usually look at reports within a day or two. We won't always tell you what we did, but we will read what you sent us.
+
+You won't get in trouble for reporting in good faith, even if we end up deciding the post is fine. We'd rather get a report that turns out to be nothing than miss something real.
+
+[SCREENSHOT: Contact page form with a sample report message filled in]
+
+## Need help?
+
+If you reported something and a week has gone by with no change, ping us again on the [contact page](https://extrachill.com/contact/) — sometimes things slip through. We'd rather hear from you twice than not at all.


### PR DESCRIPTION
Drafts for the gaps in #17. Five files in `drafts/community/`, each 350-390 words, no frontmatter, screenshot placeholders, "Need help?" footers. Writing rules from #6 enforced — no plugin/platform names, no acronyms, no internal-product references, no code.

## Articles

| File | Notes |
|---|---|
| `community-ground-rules.md` | Vibe + specific dos/don'ts. Welcoming, not preachy. Links forward to report/block articles. |
| `report-a-post-or-person.md` | **User-side flow only.** Nothing about what mods see or do. |
| `block-someone.md` | **Honest about the missing feature.** Lists workarounds, describes the goal when shipped. |
| `find-something-in-the-forums.md` | Search button + browse-by-forum tips. Points at network-wide search for the cross-site case. |
| `reply-quote-and-tag-people.md` | Standalone draft on nested replies, quote-via-block, and `@`-mention conventions. |

## Judgment calls — @chubes please weigh in

### 1. Reporting and blocking aren't real features yet

Greppable confirmation: `extrachill-community/` has zero references to "report" or user blocking. There's no flag button, no block button, no moderation queue exposed to users.

I wrote both articles **honestly** rather than inventing UX:

- **Reporting** points users to the contact form, the Tech Support forum, and tagging a mod (`@chubes`). It tells them a real person reads each report.
- **Blocking** straight-up says "we don't have a block button yet" and lists workarounds (unfollow, skip thread, mute via leaving the thread, report if rules-breaking). It does NOT promise hidden DMs because there are no native DMs to begin with.

If you'd rather build the features before publishing, these drafts can sit until shipped. If you'd rather publish the honest version now and update later, the docs are ready.

### 2. Reply/quote/tag — folded or standalone?

Spec said: writer's call. I went **standalone** because:

- The existing `using-the-forums.md` is itself due for a full rewrite — it currently names "Gutenberg block editor" and "multisite authentication system," which both violate #6's rules.
- A clean standalone is easy to fold into the rewrite later.
- It's also fine on its own — nested replies, quote workflow, `@`-mention rules are a coherent topic.

Easy to reverse: when you rewrite "Using the Forums" to comply with #6, paste this content in and delete the standalone. Or ship as-is and cross-link.

### 3. Search article overlaps a future "search across the network" article

`find-something-in-the-forums.md` ends by pointing users to the main extrachill.com search bar for cross-site queries — that's the seam where the future cross-site search article would pick up. Two scoped articles probably reads cleaner than one mega-article. Up to you.

## Verification done

- Reporting article: scrubbed for moderator-only info. The phrase "real person on our team reads it" is the most insider detail and stays at the user-visible level (you'd see a response or you wouldn't).
- Blocking article: every claim verified against the codebase. No invented features, no overselling.
- Forbidden-name grep clean (no plugin/platform/protocol/acronym leakage).
- Word counts: 351 / 374 / 368 / 390 / 354.
- Sixth-grade reading level — short sentences, plain words, real examples.

Refs #17, #6.