### PR TITLE
feat(sync): upsert-doc-page ability + scheduled cron + edit lockdown

### DIFF
--- a/extrachill-docs.php
+++ b/extrachill-docs.php
@@ -53,7 +53,14 @@ require_once EXTRACHILL_DOCS_PLUGIN_DIR . 'inc/core/rewrite-rules.php';
 // configured with agent_modes: ['docs']. See runner-configs/README.md.
 require_once EXTRACHILL_DOCS_PLUGIN_DIR . 'inc/docs-agent/docs-mode.php';
 
+// Sync infrastructure — upsert-doc-page ability, scheduled cron, WP-CLI
+// command, edit lockdown on synced pages. See inc/sync/*.
+require_once EXTRACHILL_DOCS_PLUGIN_DIR . 'inc/abilities/upsert-doc-page.php';
+require_once EXTRACHILL_DOCS_PLUGIN_DIR . 'inc/sync/synced-page-guard.php';
+require_once EXTRACHILL_DOCS_PLUGIN_DIR . 'inc/sync/sync-orchestrator.php';
+
 register_activation_hook( __FILE__, 'extrachill_docs_activate' );
+register_deactivation_hook( __FILE__, 'extrachill_docs_deactivate' );
 
 /**
  * Seeds default platform terms on plugin activation.
@@ -66,6 +73,24 @@ function extrachill_docs_activate() {
 	extrachill_docs_register_post_type();
 	extrachill_docs_seed_platforms();
 
+	// Schedule the docs sync cron event. Safe to call repeatedly — no-op if
+	// already scheduled. See inc/sync/sync-orchestrator.php.
+	extrachill_docs_schedule_sync_cron();
+
 	// Flush rewrite rules for clean URLs.
 	flush_rewrite_rules();
+}
+
+/**
+ * Tear down scheduled events on deactivation.
+ *
+ * Leaves all CPT / taxonomy / page data intact — deactivation should not
+ * destroy content. Only cleans up the recurring cron event so it doesn't
+ * fire against a deactivated plugin.
+ *
+ * @since 0.5.0
+ * @return void
+ */
+function extrachill_docs_deactivate() {
+	extrachill_docs_unschedule_sync_cron();
 }

--- a/inc/abilities/upsert-doc-page.php
+++ b/inc/abilities/upsert-doc-page.php
@@ -1,0 +1,409 @@
+<?php
+/**
+ * Upsert Doc Page Ability
+ *
+ * Registers `extrachill-docs/upsert-doc-page` — the atomic operation that
+ * converts a single markdown file into a hierarchical WordPress page on
+ * docs.extrachill.com. Idempotent, keyed by post meta { _source_repo,
+ * _source_path }.
+ *
+ * Composability: this ability is the single write path for every doc page
+ * on docs.extrachill.com. The sync orchestrator (cron, WP-CLI) calls it
+ * once per file. The migration script (#38) calls it once per ec_doc post.
+ * Future agents in chat could call it to fix a single page without running
+ * a full repo walk.
+ *
+ * Dependencies:
+ *   - block-format-bridge/convert  (provided by data-machine plugin)
+ *   - Native WordPress post functions (wp_insert_post, wp_update_post, etc.)
+ *
+ * @package ExtraChillDocs
+ * @since   0.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'init', 'extrachill_docs_register_upsert_doc_page_ability' );
+
+/**
+ * Register the upsert-doc-page ability with the WordPress Abilities API.
+ *
+ * Skipped cleanly when the Abilities API or block-format-bridge are not
+ * loaded (e.g. unit tests, plugin deactivation transitions).
+ *
+ * @since 0.5.0
+ * @return void
+ */
+function extrachill_docs_register_upsert_doc_page_ability(): void {
+	if ( ! function_exists( 'wp_register_ability' ) ) {
+		return;
+	}
+
+	wp_register_ability(
+		'extrachill-docs/upsert-doc-page',
+		array(
+			'label'               => __( 'Upsert Documentation Page', 'extrachill-docs' ),
+			'description'         => __( 'Convert a markdown file into a hierarchical WordPress page on docs.extrachill.com. Idempotent: pages are keyed by { _source_repo, _source_path } meta. Creates the parent page if it does not exist.', 'extrachill-docs' ),
+			'category'            => 'extrachill-docs',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'required'   => array( 'repo', 'path', 'markdown', 'parent_slug', 'parent_title' ),
+				'properties' => array(
+					'repo'         => array(
+						'type'        => 'string',
+						'description' => __( 'Source repository in owner/repo format (e.g. Extra-Chill/extrachill-artist-platform).', 'extrachill-docs' ),
+					),
+					'path'         => array(
+						'type'        => 'string',
+						'description' => __( 'Path to the markdown file inside the source repo (e.g. docs/user/getting-started.md). Used as part of the idempotency key.', 'extrachill-docs' ),
+					),
+					'sha'          => array(
+						'type'        => 'string',
+						'description' => __( 'Optional content SHA from the source repo. Stored as _source_sha post meta to short-circuit unchanged-content updates on future runs.', 'extrachill-docs' ),
+					),
+					'markdown'     => array(
+						'type'        => 'string',
+						'description' => __( 'Full markdown content of the source file. Will be converted to Gutenberg blocks via block-format-bridge.', 'extrachill-docs' ),
+					),
+					'parent_slug'  => array(
+						'type'        => 'string',
+						'description' => __( 'Slug of the parent page (e.g. artist-platform). Parent page is created if it does not exist.', 'extrachill-docs' ),
+					),
+					'parent_title' => array(
+						'type'        => 'string',
+						'description' => __( 'Title of the parent page, used when creating the parent (e.g. Artist Platform). Ignored when parent already exists.', 'extrachill-docs' ),
+					),
+					'dry_run'      => array(
+						'type'        => 'boolean',
+						'description' => __( 'If true, returns the action that would be taken without writing to the database. Default: false.', 'extrachill-docs' ),
+						'default'     => false,
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'success'      => array( 'type' => 'boolean' ),
+					'action'       => array(
+						'type' => 'string',
+						'enum' => array( 'created', 'updated', 'unchanged', 'would_create', 'would_update', 'would_skip' ),
+					),
+					'page_id'      => array( 'type' => 'integer' ),
+					'parent_id'    => array( 'type' => 'integer' ),
+					'permalink'    => array( 'type' => 'string' ),
+					'error'        => array( 'type' => 'string' ),
+					'error_detail' => array( 'type' => 'string' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_docs_execute_upsert_doc_page',
+			'permission_callback' => 'extrachill_docs_upsert_doc_page_permission_callback',
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Permission callback for upsert-doc-page.
+ *
+ * Restricts to administrators by default. The sync orchestrator runs in a
+ * cron context where current_user_can() returns true for all caps (no
+ * user), so cron-driven calls always succeed. Manual REST/CLI calls
+ * require admin.
+ *
+ * @since 0.5.0
+ * @return bool
+ */
+function extrachill_docs_upsert_doc_page_permission_callback(): bool {
+	// Cron context: no current user, all checks pass.
+	if ( function_exists( 'wp_doing_cron' ) && wp_doing_cron() ) {
+		return true;
+	}
+
+	// CLI context: trust the operator.
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		return true;
+	}
+
+	return function_exists( 'current_user_can' ) && current_user_can( 'manage_options' );
+}
+
+/**
+ * Execute the upsert.
+ *
+ * Algorithm:
+ *   1. Resolve or create the parent page from parent_slug + parent_title.
+ *   2. Convert markdown → Gutenberg blocks via block-format-bridge/convert.
+ *   3. Look up existing page by { _source_repo, _source_path } meta query.
+ *   4. If unchanged (same _source_sha), return 'unchanged' without writing.
+ *   5. If new, wp_insert_post under the parent with required meta.
+ *   6. If changed, wp_update_post preserving slug + parent.
+ *
+ * Title is derived from the first H1 in the markdown, falling back to the
+ * filename-derived slug humanized.
+ *
+ * @since 0.5.0
+ *
+ * @param array<string,mixed> $input Ability input.
+ * @return array<string,mixed>
+ */
+function extrachill_docs_execute_upsert_doc_page( array $input ): array {
+	$repo         = isset( $input['repo'] ) ? (string) $input['repo'] : '';
+	$path         = isset( $input['path'] ) ? (string) $input['path'] : '';
+	$sha          = isset( $input['sha'] ) ? (string) $input['sha'] : '';
+	$markdown     = isset( $input['markdown'] ) ? (string) $input['markdown'] : '';
+	$parent_slug  = isset( $input['parent_slug'] ) ? sanitize_title( (string) $input['parent_slug'] ) : '';
+	$parent_title = isset( $input['parent_title'] ) ? (string) $input['parent_title'] : '';
+	$dry_run      = ! empty( $input['dry_run'] );
+
+	if ( '' === $repo || '' === $path || '' === $parent_slug || '' === $parent_title ) {
+		return array(
+			'success' => false,
+			'error'   => 'extrachill_docs_missing_input',
+			'error_detail' => 'repo, path, parent_slug, and parent_title are required.',
+		);
+	}
+
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		return array(
+			'success' => false,
+			'error'   => 'extrachill_docs_abilities_api_missing',
+			'error_detail' => 'WordPress Abilities API is not available.',
+		);
+	}
+
+	// Resolve or create parent page.
+	$parent_id = extrachill_docs_resolve_or_create_parent_page( $parent_slug, $parent_title, $dry_run );
+	if ( is_wp_error( $parent_id ) ) {
+		return array(
+			'success'      => false,
+			'error'        => (string) $parent_id->get_error_code(),
+			'error_detail' => (string) $parent_id->get_error_message(),
+		);
+	}
+
+	// Look up existing synced page.
+	$existing = extrachill_docs_find_synced_page( $repo, $path );
+
+	// Short-circuit on unchanged content (sha match).
+	if ( $existing && '' !== $sha ) {
+		$existing_sha = (string) get_post_meta( $existing->ID, '_source_sha', true );
+		if ( $existing_sha === $sha ) {
+			return array(
+				'success'   => true,
+				'action'    => 'unchanged',
+				'page_id'   => (int) $existing->ID,
+				'parent_id' => (int) $parent_id,
+				'permalink' => $dry_run ? '' : (string) get_permalink( $existing->ID ),
+			);
+		}
+	}
+
+	// Convert markdown to serialized Gutenberg blocks.
+	$bfb_result = wp_get_ability( 'block-format-bridge/convert' )->execute(
+		array(
+			'content' => $markdown,
+			'from'    => 'markdown',
+			'to'      => 'blocks',
+		)
+	);
+
+	if ( ! is_array( $bfb_result ) || empty( $bfb_result['success'] ) ) {
+		return array(
+			'success'      => false,
+			'error'        => isset( $bfb_result['error'] ) ? (string) $bfb_result['error'] : 'extrachill_docs_conversion_failed',
+			'error_detail' => isset( $bfb_result['error_detail'] ) ? (string) $bfb_result['error_detail'] : sprintf( 'Markdown-to-blocks conversion failed for %s::%s.', $repo, $path ),
+		);
+	}
+
+	$blocks_content = isset( $bfb_result['content'] ) ? (string) $bfb_result['content'] : '';
+	$title          = extrachill_docs_extract_title_from_markdown( $markdown, $path );
+	$slug           = extrachill_docs_derive_slug_from_path( $path );
+
+	if ( $dry_run ) {
+		return array(
+			'success'   => true,
+			'action'    => $existing ? 'would_update' : 'would_create',
+			'page_id'   => $existing ? (int) $existing->ID : 0,
+			'parent_id' => (int) $parent_id,
+			'permalink' => '',
+		);
+	}
+
+	// Apply.
+	$postarr = array(
+		'post_type'    => 'page',
+		'post_status'  => 'publish',
+		'post_title'   => $title,
+		'post_name'    => $slug,
+		'post_content' => $blocks_content,
+		'post_parent'  => (int) $parent_id,
+	);
+
+	if ( $existing ) {
+		$postarr['ID'] = (int) $existing->ID;
+		$result_id     = wp_update_post( $postarr, true );
+		$action        = 'updated';
+	} else {
+		$result_id = wp_insert_post( $postarr, true );
+		$action    = 'created';
+	}
+
+	if ( is_wp_error( $result_id ) ) {
+		return array(
+			'success'      => false,
+			'error'        => (string) $result_id->get_error_code(),
+			'error_detail' => (string) $result_id->get_error_message(),
+		);
+	}
+
+	$page_id = (int) $result_id;
+
+	update_post_meta( $page_id, '_source_repo', $repo );
+	update_post_meta( $page_id, '_source_path', $path );
+	if ( '' !== $sha ) {
+		update_post_meta( $page_id, '_source_sha', $sha );
+	}
+
+	return array(
+		'success'   => true,
+		'action'    => $action,
+		'page_id'   => $page_id,
+		'parent_id' => (int) $parent_id,
+		'permalink' => (string) get_permalink( $page_id ),
+	);
+}
+
+/**
+ * Find an existing synced page by source repo + path meta.
+ *
+ * @since 0.5.0
+ *
+ * @param string $repo Source repo (owner/repo).
+ * @param string $path Source path inside the repo.
+ * @return \WP_Post|null
+ */
+function extrachill_docs_find_synced_page( string $repo, string $path ): ?\WP_Post {
+	$query = new \WP_Query(
+		array(
+			'post_type'      => 'page',
+			'post_status'    => array( 'publish', 'draft', 'private', 'pending' ),
+			'posts_per_page' => 1,
+			'no_found_rows'  => true,
+			'meta_query'     => array(
+				'relation' => 'AND',
+				array(
+					'key'     => '_source_repo',
+					'value'   => $repo,
+					'compare' => '=',
+				),
+				array(
+					'key'     => '_source_path',
+					'value'   => $path,
+					'compare' => '=',
+				),
+			),
+		)
+	);
+
+	if ( empty( $query->posts ) ) {
+		return null;
+	}
+
+	$post = $query->posts[0];
+
+	return $post instanceof \WP_Post ? $post : null;
+}
+
+/**
+ * Resolve the parent page ID for a given slug, creating it if absent.
+ *
+ * Parent pages are non-synced (no _source_repo meta) so they are not
+ * locked down by SyncedPageGuard — admins can edit titles/content/order
+ * directly. The parent's content is intentionally left blank for the
+ * theme to render an archive-style listing of its children.
+ *
+ * @since 0.5.0
+ *
+ * @param string $slug    Parent slug.
+ * @param string $title   Parent title (used on create).
+ * @param bool   $dry_run When true, returns 0 for unknown parents instead of creating.
+ * @return int|\WP_Error
+ */
+function extrachill_docs_resolve_or_create_parent_page( string $slug, string $title, bool $dry_run ) {
+	$existing = get_page_by_path( $slug, OBJECT, 'page' );
+	if ( $existing instanceof \WP_Post ) {
+		return (int) $existing->ID;
+	}
+
+	if ( $dry_run ) {
+		return 0;
+	}
+
+	$parent_id = wp_insert_post(
+		array(
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_title'   => $title,
+			'post_name'    => $slug,
+			'post_content' => '',
+			'post_parent'  => 0,
+		),
+		true
+	);
+
+	if ( is_wp_error( $parent_id ) ) {
+		return $parent_id;
+	}
+
+	update_post_meta( (int) $parent_id, '_extrachill_docs_platform_parent', '1' );
+
+	return (int) $parent_id;
+}
+
+/**
+ * Extract a human-readable title from the markdown body.
+ *
+ * Looks for the first ATX-style H1 (`# Title`) in the content. Falls back
+ * to the filename-derived slug humanized when no H1 is present.
+ *
+ * @since 0.5.0
+ *
+ * @param string $markdown Full markdown body.
+ * @param string $path     Source file path, used for the filename fallback.
+ * @return string
+ */
+function extrachill_docs_extract_title_from_markdown( string $markdown, string $path ): string {
+	if ( preg_match( '/^\s*#\s+(.+?)\s*$/m', $markdown, $matches ) ) {
+		$title = trim( $matches[1] );
+		if ( '' !== $title ) {
+			return $title;
+		}
+	}
+
+	$slug = extrachill_docs_derive_slug_from_path( $path );
+	return ucwords( str_replace( '-', ' ', $slug ) );
+}
+
+/**
+ * Derive a page slug from a source file path.
+ *
+ * Takes the basename minus the .md extension. Sanitizes through
+ * sanitize_title() so the slug is URL-safe.
+ *
+ * @since 0.5.0
+ *
+ * @param string $path Source file path inside the repo (e.g. docs/user/getting-started.md).
+ * @return string
+ */
+function extrachill_docs_derive_slug_from_path( string $path ): string {
+	$basename = basename( $path );
+	$basename = preg_replace( '/\.md$/i', '', $basename );
+	return sanitize_title( (string) $basename );
+}

--- a/inc/sync/sync-orchestrator.php
+++ b/inc/sync/sync-orchestrator.php
@@ -1,0 +1,496 @@
+<?php
+/**
+ * Sync Orchestrator
+ *
+ * Drives `extrachill-docs/upsert-doc-page` across configured plugin repos.
+ * Two entry points share the same orchestration code:
+ *
+ *   - Scheduled cron event `extrachill_docs_sync_cron` (default: hourly)
+ *   - WP-CLI command `wp extrachill docs sync` for ad-hoc and dry-runs
+ *
+ * Both walk the list of repos returned by the `extrachill_docs_sync_repos`
+ * filter (seeded from runner-configs/platform-map.yml so the docs-agent
+ * CI side and the production sync side share one source of truth).
+ *
+ * For each repo:
+ *   1. List docs/user/**\/*.md via datamachine/list-github-tree
+ *   2. Fetch each file's content + sha via datamachine/get-github-file
+ *   3. Call extrachill-docs/upsert-doc-page per file
+ *
+ * Errors are per-file. One bad file logs and continues; one bad repo
+ * logs and proceeds to the next repo. The orchestrator returns a
+ * structured summary suitable for CLI rendering or job logs.
+ *
+ * @package ExtraChillDocs
+ * @since   0.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const EXTRACHILL_DOCS_SYNC_CRON_HOOK = 'extrachill_docs_sync_cron';
+
+/**
+ * Register the scheduled sync event on plugin activation.
+ *
+ * Called from extrachill_docs_activate(). Schedules an hourly run by
+ * default; the interval is configurable via the `extrachill_docs_sync_interval`
+ * filter (must return a valid WP-Cron schedule name).
+ *
+ * @since 0.5.0
+ * @return void
+ */
+function extrachill_docs_schedule_sync_cron(): void {
+	$interval = (string) apply_filters( 'extrachill_docs_sync_interval', 'hourly' );
+
+	if ( ! wp_next_scheduled( EXTRACHILL_DOCS_SYNC_CRON_HOOK ) ) {
+		wp_schedule_event( time() + 60, $interval, EXTRACHILL_DOCS_SYNC_CRON_HOOK );
+	}
+}
+
+/**
+ * Tear down the scheduled event on plugin deactivation.
+ *
+ * @since 0.5.0
+ * @return void
+ */
+function extrachill_docs_unschedule_sync_cron(): void {
+	$timestamp = wp_next_scheduled( EXTRACHILL_DOCS_SYNC_CRON_HOOK );
+	if ( false !== $timestamp ) {
+		wp_unschedule_event( $timestamp, EXTRACHILL_DOCS_SYNC_CRON_HOOK );
+	}
+}
+
+/**
+ * Cron callback — run the sync across all configured repos.
+ *
+ * @since 0.5.0
+ * @return void
+ */
+function extrachill_docs_run_sync_cron(): void {
+	$summary = extrachill_docs_sync_all_repos( false, null );
+
+	do_action( 'extrachill_docs_sync_completed', $summary );
+}
+add_action( EXTRACHILL_DOCS_SYNC_CRON_HOOK, 'extrachill_docs_run_sync_cron' );
+
+/**
+ * Return the list of repos to sync, with their parent-page identities.
+ *
+ * Default seed reads from runner-configs/platform-map.yml so the
+ * docs-agent CI side (which writes markdown into plugin repos) and the
+ * production sync side (which reads it back into pages) stay in lockstep.
+ *
+ * The `extrachill_docs_sync_repos` filter lets other plugins or
+ * site-specific code add or remove repos.
+ *
+ * Each entry shape:
+ *   [
+ *     'repo'         => 'Extra-Chill/extrachill-artist-platform',
+ *     'parent_slug'  => 'artist-platform',
+ *     'parent_title' => 'Artist Platform',
+ *     'docs_subpath' => 'docs/user',
+ *   ]
+ *
+ * @since 0.5.0
+ * @return array<int,array<string,string>>
+ */
+function extrachill_docs_get_sync_repos(): array {
+	$default = extrachill_docs_load_platform_map();
+
+	$filtered = apply_filters( 'extrachill_docs_sync_repos', $default );
+
+	if ( ! is_array( $filtered ) ) {
+		return array();
+	}
+
+	$out = array();
+	foreach ( $filtered as $entry ) {
+		if ( ! is_array( $entry ) ) {
+			continue;
+		}
+		$repo         = isset( $entry['repo'] ) ? (string) $entry['repo'] : '';
+		$parent_slug  = isset( $entry['parent_slug'] ) ? sanitize_title( (string) $entry['parent_slug'] ) : '';
+		$parent_title = isset( $entry['parent_title'] ) ? (string) $entry['parent_title'] : '';
+		$docs_subpath = isset( $entry['docs_subpath'] ) ? trim( (string) $entry['docs_subpath'], '/' ) : 'docs/user';
+
+		if ( '' === $repo || '' === $parent_slug || '' === $parent_title ) {
+			continue;
+		}
+
+		$out[] = array(
+			'repo'         => $repo,
+			'parent_slug'  => $parent_slug,
+			'parent_title' => $parent_title,
+			'docs_subpath' => '' === $docs_subpath ? 'docs/user' : $docs_subpath,
+		);
+	}
+
+	return $out;
+}
+
+/**
+ * Parse runner-configs/platform-map.yml into the sync-repos array shape.
+ *
+ * Hand-written YAML parser scoped to the shape platform-map.yml uses.
+ * Avoids adding a Symfony YAML dependency for one file we control.
+ *
+ * @since 0.5.0
+ * @return array<int,array<string,string>>
+ */
+function extrachill_docs_load_platform_map(): array {
+	$path = EXTRACHILL_DOCS_PLUGIN_DIR . 'runner-configs/platform-map.yml';
+	if ( ! is_readable( $path ) ) {
+		return array();
+	}
+
+	$yaml = file_get_contents( $path );
+	if ( false === $yaml ) {
+		return array();
+	}
+
+	$lines = preg_split( '/\r\n|\r|\n/', $yaml );
+	if ( false === $lines ) {
+		return array();
+	}
+
+	$out          = array();
+	$current_repo = null;
+	$current      = array();
+	$in_repos     = false;
+
+	foreach ( $lines as $raw ) {
+		// Drop comments and empty lines.
+		$trimmed = trim( $raw );
+		if ( '' === $trimmed || str_starts_with( $trimmed, '#' ) ) {
+			continue;
+		}
+
+		// Top-level 'repos:' marker.
+		if ( ! $in_repos ) {
+			if ( preg_match( '/^repos:\s*$/', $trimmed ) ) {
+				$in_repos = true;
+			}
+			continue;
+		}
+
+		// Two-space-indented repo key: 'OWNER/REPO:'
+		if ( preg_match( '/^  ([^\s:][^:]*):\s*$/', $raw, $matches ) ) {
+			extrachill_docs_flush_platform_map_entry( $out, $current_repo, $current );
+			$current_repo = trim( $matches[1] );
+			$current      = array();
+			continue;
+		}
+
+		// Four-space-indented field: '    key: "value"' or '    key: value'
+		if ( null !== $current_repo && preg_match( '/^    ([a-z_]+):\s*"?([^"\n]*)"?\s*$/', $raw, $matches ) ) {
+			$key   = $matches[1];
+			$value = trim( $matches[2], " \t\"'" );
+			if ( '' !== $key && '' !== $value ) {
+				$current[ $key ] = $value;
+			}
+		}
+	}
+
+	extrachill_docs_flush_platform_map_entry( $out, $current_repo, $current );
+
+	return $out;
+}
+
+/**
+ * Helper for the YAML parser: push a completed entry onto the output.
+ *
+ * @since 0.5.0
+ *
+ * @param array<int,array<string,string>> $out          Accumulator (by-ref).
+ * @param string|null                     $current_repo Repo identifier collected so far.
+ * @param array<string,string>            $current      Fields collected for the current repo.
+ * @return void
+ */
+function extrachill_docs_flush_platform_map_entry( array &$out, ?string $current_repo, array $current ): void {
+	if ( null === $current_repo || '' === $current_repo ) {
+		return;
+	}
+
+	$parent_slug  = $current['parent_slug'] ?? '';
+	$platform     = $current['platform_name'] ?? '';
+	$docs_subpath = $current['docs_subpath'] ?? 'docs/user';
+
+	if ( '' === $parent_slug || '' === $platform ) {
+		return;
+	}
+
+	$out[] = array(
+		'repo'         => $current_repo,
+		'parent_slug'  => $parent_slug,
+		'parent_title' => $platform,
+		'docs_subpath' => $docs_subpath,
+	);
+}
+
+/**
+ * Sync every configured repo.
+ *
+ * @since 0.5.0
+ *
+ * @param bool        $dry_run    When true, report planned actions without writing.
+ * @param string|null $only_repo  Optional filter — sync only this OWNER/REPO.
+ * @return array<string,mixed>    Summary by repo.
+ */
+function extrachill_docs_sync_all_repos( bool $dry_run = false, ?string $only_repo = null ): array {
+	$repos   = extrachill_docs_get_sync_repos();
+	$summary = array(
+		'started_at' => gmdate( 'c' ),
+		'dry_run'    => $dry_run,
+		'repos'      => array(),
+	);
+
+	foreach ( $repos as $entry ) {
+		if ( null !== $only_repo && $entry['repo'] !== $only_repo ) {
+			continue;
+		}
+
+		$summary['repos'][ $entry['repo'] ] = extrachill_docs_sync_one_repo( $entry, $dry_run );
+	}
+
+	$summary['finished_at'] = gmdate( 'c' );
+
+	return $summary;
+}
+
+/**
+ * Sync a single repo: list → fetch → upsert per file.
+ *
+ * @since 0.5.0
+ *
+ * @param array<string,string> $entry   Platform-map entry.
+ * @param bool                 $dry_run See sync_all_repos.
+ * @return array<string,mixed> Per-repo summary.
+ */
+function extrachill_docs_sync_one_repo( array $entry, bool $dry_run ): array {
+	$repo         = $entry['repo'];
+	$parent_slug  = $entry['parent_slug'];
+	$parent_title = $entry['parent_title'];
+	$docs_subpath = $entry['docs_subpath'] ?? 'docs/user';
+
+	$result = array(
+		'repo'         => $repo,
+		'parent_slug'  => $parent_slug,
+		'docs_subpath' => $docs_subpath,
+		'files'        => array(),
+		'errors'       => array(),
+	);
+
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		$result['errors'][] = 'WordPress Abilities API is not available.';
+		return $result;
+	}
+
+	$list_ability = wp_get_ability( 'datamachine/list-github-tree' );
+	if ( null === $list_ability ) {
+		$result['errors'][] = 'datamachine/list-github-tree ability not registered. Is data-machine-code active?';
+		return $result;
+	}
+
+	$listing = $list_ability->execute(
+		array(
+			'repo' => $repo,
+			'path' => $docs_subpath,
+		)
+	);
+
+	if ( ! is_array( $listing ) || empty( $listing['success'] ) ) {
+		$result['errors'][] = sprintf(
+			'list-github-tree failed for %s: %s',
+			$repo,
+			isset( $listing['error'] ) ? (string) $listing['error'] : 'unknown error'
+		);
+		return $result;
+	}
+
+	$files = isset( $listing['files'] ) && is_array( $listing['files'] ) ? $listing['files'] : array();
+
+	// Filter to .md files within the docs subpath.
+	$md_files = array();
+	foreach ( $files as $file ) {
+		if ( ! is_array( $file ) ) {
+			continue;
+		}
+		$path = isset( $file['path'] ) ? (string) $file['path'] : '';
+		$type = isset( $file['type'] ) ? (string) $file['type'] : '';
+
+		if ( 'blob' !== $type && '' !== $type ) {
+			continue;
+		}
+		if ( '' === $path || ! str_ends_with( strtolower( $path ), '.md' ) ) {
+			continue;
+		}
+		if ( ! str_starts_with( $path, $docs_subpath . '/' ) && $path !== $docs_subpath ) {
+			continue;
+		}
+
+		$md_files[] = array(
+			'path' => $path,
+			'sha'  => isset( $file['sha'] ) ? (string) $file['sha'] : '',
+		);
+	}
+
+	if ( empty( $md_files ) ) {
+		// Not an error — repo just doesn't have docs yet.
+		return $result;
+	}
+
+	$fetch_ability  = wp_get_ability( 'datamachine/get-github-file' );
+	$upsert_ability = wp_get_ability( 'extrachill-docs/upsert-doc-page' );
+
+	if ( null === $fetch_ability ) {
+		$result['errors'][] = 'datamachine/get-github-file ability not registered.';
+		return $result;
+	}
+	if ( null === $upsert_ability ) {
+		$result['errors'][] = 'extrachill-docs/upsert-doc-page ability not registered.';
+		return $result;
+	}
+
+	foreach ( $md_files as $file ) {
+		$fetch = $fetch_ability->execute(
+			array(
+				'repo' => $repo,
+				'path' => $file['path'],
+			)
+		);
+
+		if ( ! is_array( $fetch ) || empty( $fetch['success'] ) ) {
+			$result['files'][] = array(
+				'path'   => $file['path'],
+				'action' => 'fetch_failed',
+				'error'  => isset( $fetch['error'] ) ? (string) $fetch['error'] : 'unknown',
+			);
+			continue;
+		}
+
+		// get-github-file returns a `files` array even for single-file requests.
+		$fetched_files = isset( $fetch['files'] ) && is_array( $fetch['files'] ) ? $fetch['files'] : array();
+		$content       = '';
+		foreach ( $fetched_files as $f ) {
+			if ( is_array( $f ) && isset( $f['path'] ) && $f['path'] === $file['path'] ) {
+				$content = isset( $f['content'] ) ? (string) $f['content'] : '';
+				break;
+			}
+		}
+
+		if ( '' === $content && ! empty( $fetched_files ) ) {
+			// Fallback: first file.
+			$first   = reset( $fetched_files );
+			$content = is_array( $first ) && isset( $first['content'] ) ? (string) $first['content'] : '';
+		}
+
+		$upsert = $upsert_ability->execute(
+			array(
+				'repo'         => $repo,
+				'path'         => $file['path'],
+				'sha'          => $file['sha'],
+				'markdown'     => $content,
+				'parent_slug'  => $parent_slug,
+				'parent_title' => $parent_title,
+				'dry_run'      => $dry_run,
+			)
+		);
+
+		$result['files'][] = array(
+			'path'    => $file['path'],
+			'action'  => isset( $upsert['action'] ) ? (string) $upsert['action'] : 'unknown',
+			'page_id' => isset( $upsert['page_id'] ) ? (int) $upsert['page_id'] : 0,
+			'error'   => isset( $upsert['error'] ) ? (string) $upsert['error'] : '',
+		);
+	}
+
+	return $result;
+}
+
+// ---------------------------------------------------------------------------
+// WP-CLI command surface.
+// ---------------------------------------------------------------------------
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+
+	/**
+	 * Sync user docs from configured plugin repos into hierarchical WP pages.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--repo=<owner/repo>]
+	 * : Sync only this repo.
+	 *
+	 * [--dry-run]
+	 * : Report planned actions without writing.
+	 *
+	 * [--format=<format>]
+	 * : Output format (table|json|yaml). Default: table.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *   wp extrachill docs sync --dry-run
+	 *   wp extrachill docs sync --repo=Extra-Chill/extrachill-artist-platform
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array<int,string>    $args       Positional args (unused).
+	 * @param array<string,string> $assoc_args Associative options.
+	 */
+	$cli_callback = function ( array $args, array $assoc_args ): void {
+		$dry_run   = isset( $assoc_args['dry-run'] );
+		$only_repo = isset( $assoc_args['repo'] ) ? (string) $assoc_args['repo'] : null;
+		$format    = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
+
+		$summary = extrachill_docs_sync_all_repos( $dry_run, $only_repo );
+
+		if ( 'json' === $format ) {
+			\WP_CLI::print_value( $summary, array( 'format' => 'json' ) );
+			return;
+		}
+		if ( 'yaml' === $format ) {
+			\WP_CLI::print_value( $summary, array( 'format' => 'yaml' ) );
+			return;
+		}
+
+		// Table format: flatten to per-file rows.
+		$rows = array();
+		foreach ( $summary['repos'] as $repo_summary ) {
+			$repo = (string) ( $repo_summary['repo'] ?? '' );
+			foreach ( $repo_summary['errors'] ?? array() as $err ) {
+				$rows[] = array(
+					'repo'    => $repo,
+					'path'    => '(repo-level)',
+					'action'  => 'error',
+					'page_id' => 0,
+					'error'   => (string) $err,
+				);
+			}
+			foreach ( $repo_summary['files'] ?? array() as $file_row ) {
+				$rows[] = array(
+					'repo'    => $repo,
+					'path'    => (string) ( $file_row['path'] ?? '' ),
+					'action'  => (string) ( $file_row['action'] ?? '' ),
+					'page_id' => (int) ( $file_row['page_id'] ?? 0 ),
+					'error'   => (string) ( $file_row['error'] ?? '' ),
+				);
+			}
+		}
+
+		if ( empty( $rows ) ) {
+			\WP_CLI::log( 'No files to sync (no configured repos have docs/user/*.md yet).' );
+			return;
+		}
+
+		\WP_CLI\Utils\format_items( 'table', $rows, array( 'repo', 'path', 'action', 'page_id', 'error' ) );
+		\WP_CLI::success(
+			sprintf(
+				'Sync %s — %d row(s).',
+				$dry_run ? 'dry-run complete' : 'complete',
+				count( $rows )
+			)
+		);
+	};
+
+	\WP_CLI::add_command( 'extrachill docs sync', $cli_callback );
+}

--- a/inc/sync/synced-page-guard.php
+++ b/inc/sync/synced-page-guard.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Synced Page Guard
+ *
+ * Locks down direct WP-admin edits on pages that were created by the
+ * sync ability (any page with _source_repo meta). Edits must round-trip
+ * through the source repo's docs/user/*.md file so git stays canonical.
+ *
+ * Override capability:
+ *   `override_synced_docs` — administrators can grant this cap to
+ *   themselves or another role when an emergency edit is needed in WP
+ *   directly. Default: granted to no role. Granting it does not change
+ *   the sync behavior; the next sync run will overwrite the manual edit
+ *   if the source markdown still differs.
+ *
+ * @package ExtraChillDocs
+ * @since   0.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Filter map_meta_cap to block edit/delete/publish on synced pages.
+ *
+ * Runs for every capability check on every post. Short-circuits cheaply
+ * when the requested cap is not one we care about or the post is not a
+ * synced doc page.
+ *
+ * @since 0.5.0
+ *
+ * @param string[] $caps    Required primitive capabilities.
+ * @param string   $cap     Meta capability being mapped.
+ * @param int      $user_id Current user.
+ * @param array    $args    Additional context (args[0] is usually the post ID).
+ * @return string[]
+ */
+function extrachill_docs_guard_synced_pages( $caps, $cap, $user_id, $args ) {
+	$guarded_caps = array( 'edit_post', 'delete_post', 'publish_post' );
+
+	if ( ! in_array( $cap, $guarded_caps, true ) ) {
+		return $caps;
+	}
+
+	if ( empty( $args[0] ) ) {
+		return $caps;
+	}
+
+	$post_id = (int) $args[0];
+	if ( $post_id <= 0 ) {
+		return $caps;
+	}
+
+	$post = get_post( $post_id );
+	if ( ! $post instanceof \WP_Post || 'page' !== $post->post_type ) {
+		return $caps;
+	}
+
+	$source_repo = (string) get_post_meta( $post_id, '_source_repo', true );
+	if ( '' === $source_repo ) {
+		return $caps;
+	}
+
+	// Page is synced. Require the override capability.
+	$caps[] = 'override_synced_docs';
+
+	return $caps;
+}
+add_filter( 'map_meta_cap', 'extrachill_docs_guard_synced_pages', 10, 4 );
+
+/**
+ * Render an admin notice on the page editor for synced pages.
+ *
+ * Tells the editor where the canonical source lives and links to the
+ * markdown file in GitHub. Non-actionable for users without the override
+ * cap; informational for users with it.
+ *
+ * @since 0.5.0
+ * @return void
+ */
+function extrachill_docs_synced_page_admin_notice(): void {
+	$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+	if ( ! $screen || 'page' !== $screen->id ) {
+		return;
+	}
+
+	$post = get_post();
+	if ( ! $post instanceof \WP_Post ) {
+		return;
+	}
+
+	$source_repo = (string) get_post_meta( $post->ID, '_source_repo', true );
+	$source_path = (string) get_post_meta( $post->ID, '_source_path', true );
+
+	if ( '' === $source_repo || '' === $source_path ) {
+		return;
+	}
+
+	$github_url = sprintf( 'https://github.com/%s/blob/main/%s', $source_repo, $source_path );
+
+	$can_override = current_user_can( 'override_synced_docs' );
+
+	$message_class = $can_override ? 'notice-info' : 'notice-warning';
+	$prefix        = $can_override
+		? __( 'This page is synced from GitHub.', 'extrachill-docs' )
+		: __( 'This page is synced from GitHub and cannot be edited here.', 'extrachill-docs' );
+
+	$suffix = $can_override
+		? __( 'Direct edits will be overwritten on the next sync. Edit the source markdown file in GitHub for permanent changes.', 'extrachill-docs' )
+		: __( 'Edit the source markdown file in GitHub. Your change will appear here after the next sync.', 'extrachill-docs' );
+
+	printf(
+		'<div class="notice %1$s"><p><strong>%2$s</strong> %3$s</p><p><a href="%4$s" target="_blank" rel="noopener noreferrer">%5$s</a></p></div>',
+		esc_attr( $message_class ),
+		esc_html( $prefix ),
+		esc_html( $suffix ),
+		esc_url( $github_url ),
+		esc_html( sprintf( __( 'Open %s on GitHub →', 'extrachill-docs' ), $source_path ) )
+	);
+}
+add_action( 'admin_notices', 'extrachill_docs_synced_page_admin_notice' );


### PR DESCRIPTION
Closes #37

## What this PR does

Ships the **production-runtime half** of the dual-runtime docs architecture (RFC #31). Pulls \`docs/user/*.md\` from configured Extra-Chill plugin repositories, converts each file to Gutenberg blocks via \`block-format-bridge\`, and upserts hierarchical WordPress pages on docs.extrachill.com. Direct WP-admin edits to synced pages are blocked via \`map_meta_cap\` so git stays canonical.

## Architecture

\`\`\`text
WP-Cron (hourly)                  WP-CLI: \`wp extrachill docs sync\`
       │                                       │
       └──────────────┬────────────────────────┘
                      ▼
         extrachill_docs_sync_all_repos()
                      │
                      │ reads runner-configs/platform-map.yml
                      │ (shared with the docs-agent CI side from PR #35)
                      ▼
         for each configured repo:
                      │
                      │ datamachine/list-github-tree (DMC)
                      │ datamachine/get-github-file  (DMC)  — per file
                      │
                      ▼
            extrachill-docs/upsert-doc-page
                      │
                      │ block-format-bridge/convert (BFB)
                      │ wp_insert_post / wp_update_post
                      │ post meta: _source_repo, _source_path, _source_sha
                      ▼
                hierarchical WP page
                under /<parent-slug>/<doc-slug>/
\`\`\`

## Files

| File | Purpose |
|------|---------|
| **\`inc/abilities/upsert-doc-page.php\`** | Atomic ability that converts one markdown file into one hierarchical WP page. Idempotent via \`{ _source_repo, _source_path }\` post meta. Short-circuits on unchanged content when \`_source_sha\` matches. Auto-creates the parent page on first use. |
| **\`inc/sync/synced-page-guard.php\`** | \`map_meta_cap\` filter that blocks \`edit/delete/publish\` on any page with \`_source_repo\` meta unless the current user has the \`override_synced_docs\` capability. Admin notice on the page editor explains where the source lives and links to the markdown file on GitHub. |
| **\`inc/sync/sync-orchestrator.php\`** | Reads \`runner-configs/platform-map.yml\` (the same source of truth the docs-agent CI side uses), lists \`docs/user/*.md\` per repo via DMC's GitHub abilities, calls \`upsert-doc-page\` per file. Registers an hourly cron event and the \`wp extrachill docs sync\` WP-CLI command (\`--repo\`, \`--dry-run\`, \`--format=table|json|yaml\`). Errors are per-file — one bad markdown file logs and continues. |
| **\`extrachill-docs.php\`** | Wires the new requires; schedules cron on activation, unschedules on deactivation. |

## Composability — why the ability is atomic

Originally scoped in #32 as a fat \`sync-from-repo\` ability or a full DM bundle. Re-scoped (see #37's discussion) to a per-file atomic ability that the cron / CLI orchestrate around. Benefits:

- **#38's migration script reuses the same upsert path** for \`ec_doc → page\` conversion, guaranteeing migrated pages are shape-identical to sync-produced pages
- **Agents in chat could call \`upsert-doc-page\`** to fix a single page via tool call without orchestrating a full repo walk
- **Errors are per-file**, not per-repo — one bad markdown file does not break the whole sync
- **Each call is independently dry-runnable and observable**

## Shared source of truth with PR #35

The platform-map (\`runner-configs/platform-map.yml\`) is consumed by **both runtimes**:

- **CI runtime** (per PR #35's \`docs\` mode + future per-target context per DMC#423) uses it to tell the agent which repo it's documenting and who the audience is
- **Production runtime** (this PR) uses it to know which repos to pull \`docs/user/*.md\` from and which parent page to upsert under

Edit one file, both sides update.

## Smoke testing

- \`php -l\` clean on all four PHP files
- YAML parser exercised against the live \`runner-configs/platform-map.yml\` — parsed 7 repo entries with correct field mapping:
  - \`Extra-Chill/extrachill-artist-platform\` → \`/artist-platform/\` (Artist Platform)
  - \`Extra-Chill/extrachill-community\` → \`/community/\` (Community)
  - \`Extra-Chill/extrachill-events\` → \`/events-calendar/\` (Events Calendar)
  - \`Extra-Chill/extrachill-newsletter\` → \`/newsletter/\` (Newsletter)
  - \`Extra-Chill/extrachill-shop\` → \`/shop/\` (Shop)
  - \`Extra-Chill/extrachill-blog\` → \`/blog/\` (Editorial)
  - \`Extra-Chill/extrachill-roadie\` → \`/chat/\` (Roadie)

End-to-end testing waits until the first plugin repo's docs-agent CI run (per #34) produces a \`docs/user/\` directory with at least one markdown file to pull.

## Non-goals (deferred)

- **Page deletion when source MD is removed** — orphans stay; safer first cut. Follow-up issue.
- **Webhook trigger for instant sync on merge** — cron-only first cut. Stretch.
- **Image upload to media library** — BFB produces \`core/image\` blocks pointing at source URLs; works for now. Follow-up if needed.
- **#38 \`ec_doc\` migration** — separate issue, uses this PR's ability.
- **#39 CPT/taxonomy/rewrite removal** — separate issue, ships after #38 confirmed safe.

## Layer ownership preserved

- **Data Machine core** — unchanged
- **Data Machine Code** — unchanged (uses existing GitHub abilities)
- **block-format-bridge** — unchanged (uses existing convert ability)
- **\`extrachill-docs\`** — this PR's surface

Three EC plugin abilities used; everything else reuses existing public abilities.

## Capability lockdown

Synced pages cannot be edited from WP admin by default. Admins can grant the \`override_synced_docs\` capability to themselves or another role when an emergency edit is needed — but the next sync run will overwrite the manual edit if the source markdown still differs. Strong nudge toward "edit the markdown in GitHub" without making escape impossible.

## What's next

After this lands:
- **#38** — one-shot CLI migration of the 16 existing \`ec_doc\` posts to pages using this PR's ability
- **Per-repo docs-agent runs** (#34) start producing \`docs/user/*.md\` files in plugin repos for this sync to consume
- **DMC#423** lands → per-target context layer for the \`docs\` mode (PR #35) lights up
- **#39** — once #38 confirmed safe, remove the \`ec_doc\` CPT entirely