### PR TITLE
fix: register upsert-doc-page ability on wp_abilities_api_init

### DIFF
--- a/inc/abilities/upsert-doc-page.php
+++ b/inc/abilities/upsert-doc-page.php
@@ -23,7 +23,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-add_action( 'init', 'extrachill_docs_register_upsert_doc_page_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_docs_register_upsert_doc_page_ability' );
 
 /**
  * Register the upsert-doc-page ability with the WordPress Abilities API.


### PR DESCRIPTION
## Summary

The `extrachill-docs/upsert-doc-page` ability was registered on the `init` action, but WordPress 6.9 requires abilities to be registered on the **`wp_abilities_api_init`** action. Hooked to `init`, `wp_register_ability()` ran too early and the registration was rejected.

## Impact

- A `Function wp_register_ability was called incorrectly` notice was logged **~1,220x/day** in production.
- `wp_get_ability('extrachill-docs/upsert-doc-page')` returned `null`, so the docs sync orchestrator (`inc/sync/sync-orchestrator.php:343`) and the migration script (`inc/migration/ec-doc-to-page-migration.php`) both bailed silently.

## Change

One line in `inc/abilities/upsert-doc-page.php`:

```diff
-add_action( 'init', 'extrachill_docs_register_upsert_doc_page_ability' );
+add_action( 'wp_abilities_api_init', 'extrachill_docs_register_upsert_doc_page_ability' );
```

- Grepped the whole repo: this is the **only** `wp_register_ability()` call, so no other hooks needed fixing.
- The existing `function_exists( 'wp_register_ability' )` guard is preserved.

## Verification

- `php -l` clean on the changed file.
- `composer lint:php` shows **0 errors / 0 new warnings** introduced by this change (the array-alignment + meta_query warnings on this file are pre-existing and unrelated to the one-line hook swap).
- After `wp_abilities_api_init`, `wp_get_ability('extrachill-docs/upsert-doc-page')` resolves non-null and the "called incorrectly" notice no longer fires.

Fixes #43