### PR TITLE
fix: register extrachill-docs ability category to stop _doing_it_wrong notice

### DIFF
--- a/extrachill-docs.php
+++ b/extrachill-docs.php
@@ -55,6 +55,9 @@ require_once EXTRACHILL_DOCS_PLUGIN_DIR . 'inc/docs-agent/docs-mode.php';
 
 // Sync infrastructure — upsert-doc-page ability, scheduled cron, WP-CLI
 // command, edit lockdown on synced pages. See inc/sync/*.
+// The ability category must be registered before any ability assigns
+// itself to it, so load it first.
+require_once EXTRACHILL_DOCS_PLUGIN_DIR . 'inc/abilities/category.php';
 require_once EXTRACHILL_DOCS_PLUGIN_DIR . 'inc/abilities/upsert-doc-page.php';
 require_once EXTRACHILL_DOCS_PLUGIN_DIR . 'inc/sync/synced-page-guard.php';
 require_once EXTRACHILL_DOCS_PLUGIN_DIR . 'inc/sync/sync-orchestrator.php';

--- a/inc/abilities/category.php
+++ b/inc/abilities/category.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Extra Chill Docs Ability Category
+ *
+ * Single owner for the `extrachill-docs` ability category.
+ *
+ * Abilities in this plugin (e.g. `extrachill-docs/upsert-doc-page`) assign
+ * themselves to `'category' => 'extrachill-docs'`. WordPress core requires
+ * the category to be registered on the dedicated categories hook
+ * (`wp_abilities_api_categories_init`) BEFORE any ability assigns itself to
+ * it on the later abilities hook (`wp_abilities_api_init`). Without this
+ * registration, `WP_Abilities_Registry::register()` trips `_doing_it_wrong`
+ * with a "category is not registered" notice on every init.
+ *
+ * @package ExtraChillDocs
+ * @since   0.5.2
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_categories_init', 'extrachill_docs_register_ability_category' );
+
+/**
+ * Register the `extrachill-docs` ability category.
+ *
+ * Skipped cleanly when the Abilities API is not loaded (e.g. unit tests,
+ * plugin deactivation transitions).
+ *
+ * @since 0.5.2
+ * @return void
+ */
+function extrachill_docs_register_ability_category(): void {
+	if ( ! function_exists( 'wp_register_ability_category' ) ) {
+		return;
+	}
+
+	wp_register_ability_category(
+		'extrachill-docs',
+		array(
+			'label'       => __( 'Extra Chill Documentation', 'extrachill-docs' ),
+			'description' => __( 'Documentation sync and management operations for docs.extrachill.com', 'extrachill-docs' ),
+		)
+	);
+}


### PR DESCRIPTION
## The firing notice

This has been firing ~340/day for multiple days and was still hitting prod minutes before this fix:

```
PHP Notice: Function WP_Abilities_Registry::register was called incorrectly.
Ability category "extrachill-docs" is not registered. Please register the ability
category before assigning it to ability "extrachill-docs/upsert-doc-page".
```

## Root cause

`inc/abilities/upsert-doc-page.php` registers the ability `extrachill-docs/upsert-doc-page` and assigns it `'category' => 'extrachill-docs'` (line 47). But the **`extrachill-docs` ability category was never registered anywhere in the plugin** — `grep -rn "wp_register_ability_category"` returned nothing.

WP core registers ability *categories* on a separate, earlier hook (`wp_abilities_api_categories_init`) than *abilities* (`wp_abilities_api_init`). When an ability assigns itself to a category that isn't registered, `WP_Abilities_Registry::register()` trips `_doing_it_wrong`.

A prior PR (docs#44) moved the *ability* registration hook but never added the *category* registration — so the notice persisted. The fix is the missing category registration, not the ability hook.

## The fix

- New file `inc/abilities/category.php` registers the `extrachill-docs` category on the `wp_abilities_api_categories_init` hook, guarded by `function_exists( 'wp_register_ability_category' )`. Mirrors the canonical pattern in `extrachill-multisite/inc/Abilities/CategoryRegistration.php`.
- `extrachill-docs.php` requires `category.php` before `upsert-doc-page.php` so the category owner loads first.
- The existing ability registration in `upsert-doc-page.php` is unchanged.

The `extrachill-docs/upsert-doc-page` ability is the only ability assigning a category in this plugin (grep-confirmed), so this one category registration covers every assignment.

## Verification

- `php -l` clean on both touched files.
- `vendor/bin/phpcs --standard=WordPress inc/abilities/category.php` — no findings.
- Category id string matches exactly: `'extrachill-docs'` (the value of `'category'` in upsert-doc-page.php).
- Hook is `wp_abilities_api_categories_init` (categories), not `wp_abilities_api_init` (abilities).

Post-deploy verification (notice stops firing) will be confirmed on docs.extrachill.com.