### PR TITLE
fix: make responsive card grids overflow-safe (min(100%, floor))

### DIFF
--- a/assets/css/docs.css
+++ b/assets/css/docs.css
@@ -31,7 +31,7 @@
 /* Category Grid */
 .docs-category-grid {
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+	grid-template-columns: repeat(auto-fill, minmax(min(100%, 280px), 1fr));
 	gap: var(--spacing-lg);
 }
 


### PR DESCRIPTION
## Summary
Refactors the hand-rolled responsive card grid in extrachill-docs to the overflow-safe `min(100%, <floor>)` pattern. Prevents horizontal overflow when the viewport is narrower than the grid floor, with an identical layout otherwise.

Adopts the card-grid pattern from Extra-Chill/extrachill-components#16 **locally only** — extrachill-docs does not load the shared `@extrachill/components` stylesheet, so no dependency is added.

## Grids fixed
- `assets/css/docs.css` (`.docs-category-grid`, ~line 34): `repeat(auto-fill, minmax(280px, 1fr))` → `repeat(auto-fill, minmax(min(100%, 280px), 1fr))`

Surgical change: `auto-fill` preserved, floor (`280px`) preserved, `gap` unchanged, no CSS restructuring.

## Verification
- Grepped `repeat(auto-f` — this is the only responsive grid in the plugin.
- No CSS build/dist pipeline (single tracked `assets/css/docs.css`, no source→build compilation, no minified variant); CSS ships as-is.
- No JS/CSS build or lint scripts (composer only defines PHP `phpcs`/`phpcbf`, untouched here). CSS remains valid.

Refs #16