### PR TITLE
fix: resolve PHPCS + ESLint errors blocking release preflight

### DIFF
--- a/assets/js/docs-toc.js
+++ b/assets/js/docs-toc.js
@@ -4,40 +4,45 @@
  * Progressive enhancement: highlights current section as user scrolls.
  * Works without JS (links still function), enhanced with JS.
  *
- * @package ExtraChillDocs
  * @since 0.3.0
  */
 (function () {
 	'use strict';
 
-	var toc = document.querySelector('.docs-toc');
-	if (!toc) return;
+	const toc = document.querySelector('.docs-toc');
+	if (!toc) {
+		return;
+	}
 
-	var links = Array.prototype.slice.call(toc.querySelectorAll('.docs-toc-link'));
-	if (!links.length) return;
+	const links = Array.prototype.slice.call(toc.querySelectorAll('.docs-toc-link'));
+	if (!links.length) {
+		return;
+	}
 
 	// Build array of sections with their elements.
-	var sections = links
+	const sections = links
 		.map(function (link) {
-			var id = link.getAttribute('href').slice(1);
-			var header = document.getElementById(id);
-			return { link: link, header: header };
+			const id = link.getAttribute('href').slice(1);
+			const header = document.getElementById(id);
+			return { link, header };
 		})
 		.filter(function (s) {
 			return s.header;
 		});
 
-	if (!sections.length) return;
+	if (!sections.length) {
+		return;
+	}
 
 	// Offset for fixed header.
-	var headerOffset = 80;
+	const headerOffset = 80;
 
 	function updateActiveLink() {
-		var scrollPos = window.scrollY + headerOffset;
+		const scrollPos = window.scrollY + headerOffset;
 
 		// Find current section (last one that's above scroll position).
-		var current = sections[0];
-		for (var i = 0; i < sections.length; i++) {
+		let current = sections[0];
+		for (let i = 0; i < sections.length; i++) {
 			if (sections[i].header.offsetTop <= scrollPos) {
 				current = sections[i];
 			} else {
@@ -55,11 +60,13 @@
 	}
 
 	// Throttled scroll handler.
-	var ticking = false;
+	let ticking = false;
 	function onScroll() {
-		if (ticking) return;
+		if (ticking) {
+			return;
+		}
 		ticking = true;
-		requestAnimationFrame(function () {
+		window.requestAnimationFrame(function () {
 			updateActiveLink();
 			ticking = false;
 		});
@@ -70,13 +77,13 @@
 	// Smooth scroll on click.
 	links.forEach(function (link) {
 		link.addEventListener('click', function (e) {
-			var id = link.getAttribute('href').slice(1);
-			var target = document.getElementById(id);
+			const id = link.getAttribute('href').slice(1);
+			const target = document.getElementById(id);
 			if (target) {
 				e.preventDefault();
-				var top = target.offsetTop - headerOffset + 10;
-				window.scrollTo({ top: top, behavior: 'smooth' });
-				history.pushState(null, '', '#' + id);
+				const top = target.offsetTop - headerOffset + 10;
+				window.scrollTo({ top, behavior: 'smooth' });
+				window.history.pushState(null, '', '#' + id);
 			}
 		});
 	});

--- a/inc/abilities/upsert-doc-page.php
+++ b/inc/abilities/upsert-doc-page.php
@@ -164,16 +164,16 @@ function extrachill_docs_execute_upsert_doc_page( array $input ): array {
 
 	if ( '' === $repo || '' === $path || '' === $parent_slug || '' === $parent_title ) {
 		return array(
-			'success' => false,
-			'error'   => 'extrachill_docs_missing_input',
+			'success'      => false,
+			'error'        => 'extrachill_docs_missing_input',
 			'error_detail' => 'repo, path, parent_slug, and parent_title are required.',
 		);
 	}
 
 	if ( ! function_exists( 'wp_get_ability' ) ) {
 		return array(
-			'success' => false,
-			'error'   => 'extrachill_docs_abilities_api_missing',
+			'success'      => false,
+			'error'        => 'extrachill_docs_abilities_api_missing',
 			'error_detail' => 'WordPress Abilities API is not available.',
 		);
 	}

--- a/inc/core/breadcrumbs.php
+++ b/inc/core/breadcrumbs.php
@@ -154,7 +154,7 @@ function extrachill_docs_schema_breadcrumb_items( $items ) {
 
 	$main_site_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'main' ) : 'https://extrachill.com';
 
-	// Homepage: Extra Chill → Documentation
+	// Homepage: Extra Chill → Documentation.
 	if ( is_front_page() ) {
 		return array(
 			array(
@@ -168,7 +168,7 @@ function extrachill_docs_schema_breadcrumb_items( $items ) {
 		);
 	}
 
-	// Platform taxonomy archive: Extra Chill → Documentation → Platform Name
+	// Platform taxonomy archive: Extra Chill → Documentation → Platform Name.
 	if ( is_tax( 'ec_doc_platform' ) ) {
 		$term = get_queried_object();
 		return array(
@@ -187,7 +187,7 @@ function extrachill_docs_schema_breadcrumb_items( $items ) {
 		);
 	}
 
-	// Single doc: Extra Chill → Documentation → Platform Name → Doc Title
+	// Single doc: Extra Chill → Documentation → Platform Name → Doc Title.
 	if ( is_singular( 'ec_doc' ) ) {
 		$breadcrumbs = array(
 			array(
@@ -204,7 +204,7 @@ function extrachill_docs_schema_breadcrumb_items( $items ) {
 		$terms = get_the_terms( $post->ID, 'ec_doc_platform' );
 
 		if ( $terms && ! is_wp_error( $terms ) ) {
-			$platform = reset( $terms );
+			$platform      = reset( $terms );
 			$breadcrumbs[] = array(
 				'name' => $platform->name,
 				'url'  => get_term_link( $platform ),

--- a/inc/core/filters.php
+++ b/inc/core/filters.php
@@ -15,8 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 add_filter(
 	'extrachill_post_meta_parts',
-	function( $parts, $post_id, $post_type ) {
-		if ( $post_type === 'ec_doc' ) {
+	function ( $parts, $post_id, $post_type ) {
+		if ( 'ec_doc' === $post_type ) {
 			return array( 'published', 'updated' );
 		}
 		return $parts;
@@ -28,9 +28,9 @@ add_filter(
 // Allow ec_doc_platform taxonomy for related posts on ec_doc.
 add_filter(
 	'extrachill_related_posts_allowed_taxonomies',
-	function( $allowed, $post_type ) {
-		if ( $post_type === 'ec_doc' ) {
-			return [ 'ec_doc_platform' ];
+	function ( $allowed, $post_type ) {
+		if ( 'ec_doc' === $post_type ) {
+			return array( 'ec_doc_platform' );
 		}
 		return $allowed;
 	},
@@ -41,9 +41,9 @@ add_filter(
 // Use ec_doc_platform taxonomy for related posts on ec_doc.
 add_filter(
 	'extrachill_related_posts_taxonomies',
-	function( $taxonomies, $post_id, $post_type ) {
-		if ( $post_type === 'ec_doc' ) {
-			return [ 'ec_doc_platform' ];
+	function ( $taxonomies, $post_id, $post_type ) {
+		if ( 'ec_doc' === $post_type ) {
+			return array( 'ec_doc_platform' );
 		}
 		return $taxonomies;
 	},
@@ -54,8 +54,8 @@ add_filter(
 // Query ec_doc post type for related posts on ec_doc.
 add_filter(
 	'extrachill_related_posts_query_args',
-	function( $args, $taxonomy, $post_id, $post_type ) {
-		if ( $post_type === 'ec_doc' ) {
+	function ( $args, $taxonomy, $post_id, $post_type ) {
+		if ( 'ec_doc' === $post_type ) {
 			$args['post_type'] = 'ec_doc';
 		}
 		return $args;
@@ -67,7 +67,7 @@ add_filter(
 // Override sidebar content for documentation posts.
 add_filter(
 	'extrachill_sidebar_content',
-	function( $sidebar_content ) {
+	function ( $sidebar_content ) {
 		if ( is_singular( 'ec_doc' ) ) {
 			return extrachill_docs_generate_sidebar( get_the_ID() );
 		}
@@ -78,7 +78,7 @@ add_filter(
 // Override back-to-home label for documentation site.
 add_filter(
 	'extrachill_back_to_home_label',
-	function( $label, $url ) {
+	function ( $label, $url ) {
 		if ( is_singular( 'ec_doc' ) || is_post_type_archive( 'ec_doc' ) || is_tax( 'ec_doc_platform' ) ) {
 			return '← Back to Documentation';
 		}

--- a/inc/core/filters.php
+++ b/inc/core/filters.php
@@ -78,7 +78,8 @@ add_filter(
 // Override back-to-home label for documentation site.
 add_filter(
 	'extrachill_back_to_home_label',
-	function ( $label, $url ) {
+	// $url is part of the filter signature (arity 2) but unused by this callback.
+	function ( $label, $url ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		if ( is_singular( 'ec_doc' ) || is_post_type_archive( 'ec_doc' ) || is_tax( 'ec_doc_platform' ) ) {
 			return '← Back to Documentation';
 		}

--- a/inc/core/rewrite-rules.php
+++ b/inc/core/rewrite-rules.php
@@ -16,14 +16,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Add custom rewrite rules for ec_doc posts and ec_doc_platform taxonomy
  */
 function extrachill_docs_add_rewrite_rules() {
-	// Platform archive: /{platform-slug}/
+	// Platform archive: /{platform-slug}/.
 	add_rewrite_rule(
 		'^([^/]+)/?$',
 		'index.php?ec_doc_platform=$matches[1]',
 		'top'
 	);
 
-	// Single doc: /{platform-slug}/{doc-slug}/
+	// Single doc: /{platform-slug}/{doc-slug}/.
 	add_rewrite_rule(
 		'^([^/]+)/([^/]+)/?$',
 		'index.php?ec_doc=$matches[2]&ec_doc_platform=$matches[1]',
@@ -40,7 +40,7 @@ add_action( 'init', 'extrachill_docs_add_rewrite_rules', 20 );
  * @return string Modified permalink.
  */
 function extrachill_docs_post_type_link( $post_link, $post ) {
-	if ( $post->post_type !== 'ec_doc' ) {
+	if ( 'ec_doc' !== $post->post_type ) {
 		return $post_link;
 	}
 
@@ -63,7 +63,7 @@ add_filter( 'post_type_link', 'extrachill_docs_post_type_link', 10, 2 );
  * @return string Modified term link.
  */
 function extrachill_docs_term_link( $termlink, $term, $taxonomy ) {
-	if ( $taxonomy !== 'ec_doc_platform' ) {
+	if ( 'ec_doc_platform' !== $taxonomy ) {
 		return $termlink;
 	}
 

--- a/inc/core/sidebar.php
+++ b/inc/core/sidebar.php
@@ -38,19 +38,22 @@ function extrachill_docs_generate_sidebar( $post_id ) {
 	}
 
 	// Build array of headers.
-	$headers = [];
+	$headers = array();
 	foreach ( $matches as $match ) {
-		$headers[] = [
+		$headers[] = array(
 			'id'   => $match[1],
 			'text' => wp_strip_all_tags( $match[2] ),
-		];
+		);
 	}
 
 	ob_start();
 	?>
 	<nav class="docs-toc sidebar-card" aria-label="Table of Contents">
 		<h3 class="docs-toc-title"><span>On This Page</span></h3>
-		<?php echo extrachill_docs_build_toc_list( $headers ); ?>
+		<?php
+		// extrachill_docs_build_toc_list() returns markup escaped per-field with esc_attr()/esc_html().
+		echo extrachill_docs_build_toc_list( $headers ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		?>
 	</nav>
 	<?php
 	return ob_get_clean();

--- a/inc/docs-agent/docs-mode.php
+++ b/inc/docs-agent/docs-mode.php
@@ -63,16 +63,18 @@ add_action( 'datamachine_agent_modes', 'extrachill_docs_register_docs_mode' );
  *
  * @param string $content Existing guidance text (empty by default for new modes).
  * @param array  $payload Full AI request payload (agent_id, flow_step_id, etc.).
+ *                        Part of the filter signature; unused by this provider.
  * @return string Guidance text injected into the system context at priority 22.
  */
-function extrachill_docs_provide_docs_mode_guidance( string $content, array $payload ): string {
+function extrachill_docs_provide_docs_mode_guidance( string $content, array $payload ): string { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 	$rules_path = EXTRACHILL_DOCS_PLUGIN_DIR . 'runner-configs/writing-rules.md';
 
 	if ( ! is_readable( $rules_path ) ) {
 		return $content;
 	}
 
-	$rules = file_get_contents( $rules_path );
+	// Local plugin file read (not a remote URL); WP_Filesystem/wp_remote_get do not apply.
+	$rules = file_get_contents( $rules_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 	if ( false === $rules || '' === trim( $rules ) ) {
 		return $content;
 	}

--- a/inc/migration/ec-doc-to-page-migration.php
+++ b/inc/migration/ec-doc-to-page-migration.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ec_doc → Hierarchical Page Migration
+ * Ec_doc → Hierarchical Page Migration
  *
  * One-shot WP-CLI command that converts the existing ec_doc posts on
  * docs.extrachill.com into hierarchical WordPress pages using the same
@@ -158,10 +158,10 @@ function extrachill_docs_migration_migrate_one( \WP_Post $ec_doc, bool $dry_run 
 		return $row;
 	}
 
-	$term         = $terms[0];
-	$parent_slug  = (string) $term->slug;
-	$repo_map     = extrachill_docs_migration_term_to_repo_map();
-	$source_repo  = $repo_map[ $parent_slug ] ?? '';
+	$term        = $terms[0];
+	$parent_slug = (string) $term->slug;
+	$repo_map    = extrachill_docs_migration_term_to_repo_map();
+	$source_repo = $repo_map[ $parent_slug ] ?? '';
 
 	if ( '' === $source_repo ) {
 		$row['action'] = 'error';

--- a/inc/migration/ec-doc-to-page-migration.php
+++ b/inc/migration/ec-doc-to-page-migration.php
@@ -396,7 +396,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			$uploads = wp_upload_dir();
 			if ( empty( $uploads['error'] ) ) {
 				$log_path = trailingslashit( $uploads['basedir'] ) . sprintf( 'extrachill-docs-migration-%s.log', gmdate( 'Ymd-His' ) );
-				file_put_contents( $log_path, wp_json_encode( $summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+				// One-shot WP-CLI migration log write to the uploads dir; WP_Filesystem is unnecessary ceremony here.
+				file_put_contents( $log_path, wp_json_encode( $summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 				\WP_CLI::log( sprintf( 'Migration log written to: %s', $log_path ) );
 			}
 		}

--- a/inc/sync/sync-orchestrator.php
+++ b/inc/sync/sync-orchestrator.php
@@ -173,7 +173,7 @@ function extrachill_docs_load_platform_map(): array {
 			continue;
 		}
 
-		// Two-space-indented repo key: 'OWNER/REPO:'
+		// Two-space-indented repo key: 'OWNER/REPO:'.
 		if ( preg_match( '/^  ([^\s:][^:]*):\s*$/', $raw, $matches ) ) {
 			extrachill_docs_flush_platform_map_entry( $out, $current_repo, $current );
 			$current_repo = trim( $matches[1] );
@@ -181,7 +181,7 @@ function extrachill_docs_load_platform_map(): array {
 			continue;
 		}
 
-		// Four-space-indented field: '    key: "value"' or '    key: value'
+		// Four-space-indented field: '    key: "value"' or '    key: value'.
 		if ( null !== $current_repo && preg_match( '/^    ([a-z_]+):\s*"?([^"\n]*)"?\s*$/', $raw, $matches ) ) {
 			$key   = $matches[1];
 			$value = trim( $matches[2], " \t\"'" );

--- a/inc/sync/sync-orchestrator.php
+++ b/inc/sync/sync-orchestrator.php
@@ -143,7 +143,8 @@ function extrachill_docs_load_platform_map(): array {
 		return array();
 	}
 
-	$yaml = file_get_contents( $path );
+	// Local plugin-bundled YAML read (not a remote URL); WP_Filesystem/wp_remote_get do not apply.
+	$yaml = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 	if ( false === $yaml ) {
 		return array();
 	}

--- a/inc/sync/synced-page-guard.php
+++ b/inc/sync/synced-page-guard.php
@@ -97,7 +97,8 @@ function extrachill_docs_synced_page_admin_notice(): void {
 
 	$github_url = sprintf( 'https://github.com/%s/blob/main/%s', $source_repo, $source_path );
 
-	$can_override = current_user_can( 'override_synced_docs' );
+	// 'override_synced_docs' is a custom capability granted to docs editors; the sniff cannot see it.
+	$can_override = current_user_can( 'override_synced_docs' ); // phpcs:ignore WordPress.WP.Capabilities.Unknown
 
 	$message_class = $can_override ? 'notice-info' : 'notice-warning';
 	$prefix        = $can_override

--- a/inc/sync/synced-page-guard.php
+++ b/inc/sync/synced-page-guard.php
@@ -114,6 +114,7 @@ function extrachill_docs_synced_page_admin_notice(): void {
 		esc_html( $prefix ),
 		esc_html( $suffix ),
 		esc_url( $github_url ),
+		/* translators: %s: source file path in the docs repository. */
 		esc_html( sprintf( __( 'Open %s on GitHub →', 'extrachill-docs' ), $source_path ) )
 	);
 }

--- a/scripts/FileFinder.php
+++ b/scripts/FileFinder.php
@@ -2,7 +2,7 @@
 
 class FileFinder {
 	public static function find( string $directory, string $extension ): array {
-		$files = [];
+		$files    = array();
 		$iterator = new RecursiveIteratorIterator(
 			new RecursiveDirectoryIterator( $directory, RecursiveDirectoryIterator::SKIP_DOTS )
 		);

--- a/scripts/WordPressClient.php
+++ b/scripts/WordPressClient.php
@@ -1,8 +1,24 @@
 <?php
+/**
+ * WordPress REST API client for the standalone docs uploader.
+ *
+ * Standalone command-line helper loaded by scripts/upload.php OUTSIDE the
+ * WordPress runtime. WordPress HTTP/escaping helpers are unavailable, so the
+ * script talks to the REST API directly over cURL and surfaces failures as
+ * plain Exception messages (no browser output). The WordPress runtime sniffs
+ * below are disabled for this dev-only CLI helper:
+ *
+ *  - Security.EscapeOutput   : Exception messages are read from a terminal.
+ *  - WP.AlternativeFunctions : wp_remote_* / wp_json_encode are not loaded here.
+ *
+ * @package ExtraChillDocs
+ */
+
+// phpcs:disable WordPress.Security.EscapeOutput, WordPress.WP.AlternativeFunctions, WordPress.PHP.DiscouragedPHPFunctions
 
 /**
- * Class WordPressClient
- * 
+ * Class WordPressClient.
+ *
  * Handles low-level HTTP communication with the WordPress REST API.
  * Encapsulates authentication and cURL logic.
  */
@@ -27,8 +43,8 @@ class WordPressClient {
 	/**
 	 * Make an authenticated request to the WordPress API.
 	 *
-	 * @param string $method HTTP method (GET, POST, DELETE, etc.)
-	 * @param string $endpoint API endpoint (relative to site URL, e.g., '/wp-json/extrachill/v1/...')
+	 * @param string     $method HTTP method (GET, POST, DELETE, etc.)
+	 * @param string     $endpoint API endpoint (relative to site URL, e.g., '/wp-json/extrachill/v1/...')
 	 * @param array|null $data Optional data to send as JSON body
 	 * @return array Decoded JSON response
 	 * @throws Exception On cURL error or HTTP error status
@@ -37,16 +53,16 @@ class WordPressClient {
 		$url = $this->site_url . $endpoint;
 		$ch  = curl_init();
 
-		$headers = [
+		$headers = array(
 			$this->auth_header,
 			'Accept: application/json',
 			'Content-Type: application/json',
-		];
+		);
 
 		$json_data = null;
-		if ( $data !== null ) {
+		if ( null !== $data ) {
 			$json_data = json_encode( $data );
-			if ( $json_data === false ) {
+			if ( false === $json_data ) {
 				throw new Exception( 'Failed to encode JSON data: ' . json_last_error_msg() );
 			}
 			$headers[] = 'Content-Length: ' . strlen( $json_data );
@@ -54,17 +70,17 @@ class WordPressClient {
 
 		curl_setopt_array(
 			$ch,
-			[
+			array(
 				CURLOPT_URL            => $url,
 				CURLOPT_RETURNTRANSFER => true,
 				CURLOPT_CUSTOMREQUEST  => $method,
 				CURLOPT_HTTPHEADER     => $headers,
 				CURLOPT_SSL_VERIFYPEER => true,
 				CURLOPT_TIMEOUT        => 30,
-			]
+			)
 		);
 
-		if ( $json_data !== null ) {
+		if ( null !== $json_data ) {
 			curl_setopt( $ch, CURLOPT_POSTFIELDS, $json_data );
 		}
 
@@ -83,7 +99,7 @@ class WordPressClient {
 		}
 
 		$decoded = json_decode( $response, true );
-		if ( $decoded === null && json_last_error() !== JSON_ERROR_NONE ) {
+		if ( null === $decoded && JSON_ERROR_NONE !== json_last_error() ) {
 			throw new Exception( "Invalid JSON response. HTTP: {$http_code}" );
 		}
 

--- a/scripts/upload.php
+++ b/scripts/upload.php
@@ -1,20 +1,33 @@
 <?php
 /**
- * Extra Chill Docs Uploader
- * Uploads user-facing markdown documentation to docs.extrachill.com.
- * Usage: php upload.php <docs_directory> [--force]
+ * Extra Chill Docs Uploader.
+ *
+ * Standalone command-line sync tool. Runs as `php upload.php <docs_directory>`
+ * OUTSIDE of the WordPress runtime, so WordPress escaping/HTTP helpers are not
+ * available and terminal output carries no XSS surface. The WordPress runtime
+ * sniffs below are therefore disabled for this dev-only CLI script:
+ *
+ *  - Security.EscapeOutput      : output goes to a terminal, not a browser.
+ *  - WP.GlobalVariablesOverride : $title/$action are locals; WP globals are not
+ *                                 loaded in this standalone script.
+ *  - WP.AlternativeFunctions    : wp_remote_* / WP_Filesystem are unavailable here.
+ *  - DateTime.RestrictedFunctions: date() formats an ISO-8601 payload field.
+ *
+ * @package ExtraChillDocs
  */
+
+// phpcs:disable WordPress.Security.EscapeOutput, WordPress.WP.GlobalVariablesOverride, WordPress.WP.AlternativeFunctions, WordPress.DateTime.RestrictedFunctions
 
 require_once __DIR__ . '/WordPressClient.php';
 require_once __DIR__ . '/FileFinder.php';
 
-// Check arguments
+// Check arguments.
 if ( $argc < 2 ) {
 	die( "Usage: php upload.php <docs_directory> [--force]\n" );
 }
 
 $docs_dir = rtrim( $argv[1], '/' );
-$force    = isset( $argv[2] ) && $argv[2] === '--force';
+$force    = isset( $argv[2] ) && '--force' === $argv[2];
 
 if ( ! is_dir( $docs_dir ) ) {
 	die( "Error: Directory not found: $docs_dir\n" );
@@ -23,12 +36,12 @@ if ( ! is_dir( $docs_dir ) ) {
 try {
 	$client = new WordPressClient();
 } catch ( Exception $e ) {
-	die( "Initialization Error: " . $e->getMessage() . "\n" );
+	die( 'Initialization Error: ' . $e->getMessage() . "\n" );
 }
 
 echo "Starting sync from: $docs_dir\n";
 
-// Iterate through platform subdirectories
+// Iterate through platform subdirectories.
 $platforms = glob( $docs_dir . '/*', GLOB_ONLYDIR );
 
 foreach ( $platforms as $platform_dir ) {
@@ -44,10 +57,10 @@ foreach ( $platforms as $platform_dir ) {
 		$timestamp     = filemtime( $file_path );
 		$slug          = basename( $file_path, '.md' );
 
-		// Title: H1 header > filename slug
+		// Title: H1 header > filename slug.
 		$title = ucfirst( str_replace( '-', ' ', $slug ) );
 
-		// Extract H1 header as title and strip from content
+		// Extract H1 header as title and strip from content.
 		if ( preg_match( '/^#\s+(.+)$/m', $content, $h1_match ) ) {
 			$title   = trim( $h1_match[1] );
 			$content = trim( preg_replace( '/^#\s+.+$/m', '', $content, 1 ) );
@@ -56,16 +69,20 @@ foreach ( $platforms as $platform_dir ) {
 		echo "  Syncing: $relative_path... ";
 
 		try {
-			$response = $client->request( 'POST', '/wp-json/extrachill/v1/sync/doc', [
-				'slug'          => $slug,
-				'title'         => $title,
-				'content'       => $content,
-				'platform_slug' => $platform_slug,
-				'filesize'      => $filesize,
-				'timestamp'     => date( 'c', $timestamp ),
-				'force'         => $force,
-				'source_file'   => $relative_path,
-			] );
+			$response = $client->request(
+				'POST',
+				'/wp-json/extrachill/v1/sync/doc',
+				array(
+					'slug'          => $slug,
+					'title'         => $title,
+					'content'       => $content,
+					'platform_slug' => $platform_slug,
+					'filesize'      => $filesize,
+					'timestamp'     => date( 'c', $timestamp ),
+					'force'         => $force,
+					'source_file'   => $relative_path,
+				)
+			);
 
 			if ( isset( $response['success'] ) && $response['success'] ) {
 				$action = $response['action'] ?? 'updated';
@@ -74,7 +91,7 @@ foreach ( $platforms as $platform_dir ) {
 				echo "FAILED\n";
 			}
 		} catch ( Exception $e ) {
-			echo "ERROR: " . $e->getMessage() . "\n";
+			echo 'ERROR: ' . $e->getMessage() . "\n";
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The `homeboy release extrachill-docs` preflight runs **lint as a single all-or-nothing gate** across three producers — **PHPCS**, **ESLint**, **PHPStan** — and it was failing with **113 findings** (65 PHPCS + 23 ESLint + 25 PHPStan). This is pre-existing whole-tree debt: PR-scoped CI only lints *changed* files, so it went unnoticed until the release gate ran the full tree.

This PR clears the two mechanical producers to green:

- **PHPCS: `failed` (65) → `passed` (0 findings)**
- **ESLint: `failed` (23) → `passed` (0 findings)**
- PHPStan: still `failed` (25) — substantive, tracked separately in #47.

Verified with `homeboy lint extrachill-docs`: `phpcs passed:0, eslint passed:0`.

## Triage: false positives vs real errors

I checked homeboy's lint scope first. **No homeboy scope bug** — homeboy's WordPress ruleset already excludes `vendor/`, `build/`, `node_modules/`, `tests/`, and `WordPress.Files.FileName.*`. Every finding was in first-party code, so there was nothing to fix in homeboy and no false-positive issue to file against it.

The triage that *did* matter was `inc/` (deployed plugin) vs `scripts/` (standalone CLI tooling):

- **`inc/` + main plugin file** — real WordPress runtime code. All errors fixed properly in place.
- **`scripts/`** — standalone CLI sync tools run as `php upload.php` **outside** the WordPress runtime (see issue #7, which plans to retire this markdown-push pipeline). There, `wp_remote_*`/`esc_html()`/WP globals are unavailable and terminal output has no XSS surface, so a subset of WP-runtime sniffs are semantically inapplicable. Handled with documented, narrowly-scoped `phpcs:disable` blocks — Yoda conditions were still fixed properly.

## What changed

### PHPCS (commits 1 & 3)
- **phpcbf auto-fixed 33 mechanical findings** — short-array syntax, function-keyword spacing, statement/array alignment, whitespace.
- **`inc/` real fixes** — Yoda conditions, inline-comment end punctuation, a `translators:` comment, a doc-comment capital, and a scoped `EscapeOutput` ignore on a TOC helper that returns per-field-escaped markup.
- **`scripts/` fixes** — Yoda conditions fixed properly; documented file-level `phpcs:disable` for `EscapeOutput`, `GlobalVariablesOverride` (false positive — `$title`/`$action` are locals in a non-WP script), `AlternativeFunctions`, and `DateTime.RestrictedFunctions`.
- **6 residual warnings cleared** — homeboy's phpcs producer reports `failed` on warnings too, so 0 findings (not just 0 errors) is required. Added narrowly-scoped, documented `phpcs:ignore` for two unused filter-callback params, three local-file reads/writes WPCS wants via `WP_Filesystem`, and one custom capability the sniff can't resolve.

### ESLint (commit 2)
- `assets/js/docs-toc.js`: `var` → `const`/`let`, added braces to single-line `if` guards, object shorthand, prefixed browser globals (`window.requestAnimationFrame`, `window.history`), dropped the non-empty `@package` tag that tripped `jsdoc/empty-tags`. Scroll-tracking/smooth-scroll behavior unchanged.

No functional behavior changed anywhere — this is lint-debt paydown following the established whole-tree precedent (data-machine #2843).

## Not in scope here → tracked in #47

**PHPStan (25 errors at level 7)** is a separate, larger effort: 3 cross-plugin `function.notFound` (need a `phpstan.neon` ignore or stubs), 4 `property.notFound` needing `instanceof` guards, 13 `argument.type`, 2 `return.type`, plus 3 always-true/non-iterable fixes. Because the release gate is all-or-nothing, **fixing PHPCS alone does not fully unblock `homeboy release`** — #47 tracks the last producer. Filed: https://github.com/Extra-Chill/extrachill-docs/issues/47

## Test plan
- `homeboy lint extrachill-docs` → phpcs `passed` (0), eslint `passed` (0), phpstan `failed` (25, tracked in #47).
- Changes are lint-only; no logic paths altered. SQL/query logic untouched (no `$wpdb->prepare` changes were needed).